### PR TITLE
Resin SDK for Python v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [1.1.0] - 2015-10-02
+
+### Added
+
+- Implement Resin API Key. User can authorize by credentials, auth token or set Resin API key as RESIN_API_KEY environment variable.
+- Implement `resin.models.device.restart()`
+- Implement `resin.models.device.has_device_url()`
+- Implement `resin.models.device.get_device_url()`
+- Implement `resin.models.device.enable_device_url()`
+- Implement `resin.models.device.disable_device_url()`
+
+### Changed
+
+- Fix `resin.auth.is_logged_in()` remove auth token.
+- Fix bug with API endpoints in some functions.
+- Implement `login` flag that marks functions only work if users authorize by credentials or auth token.
+
+### Removed
+
+- Remove `VALID_OPTIONS` in resin.models.device_os that blocks extra os parameters when downloading an image.
+- Remove `resin.models.config.get_pubnub_keys()`.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -3,7 +3,7 @@
 Welcome to the Resin Python SDK documentation.
 This document aims to describe all the functions supported by the SDK, as well as
 showing examples of their expected usage.
-If you feel something is missing, not clear or could be improved, please don't 
+If you feel something is missing, not clear or could be improved, please don't
 hesitate to open an issue in GitHub, we'll be happy to help.
 
 ## Table of Contents
@@ -29,7 +29,7 @@ This module implements all models for Resin Python SDK.
 This class implements application model for Resin Python SDK.
 ### Function: create(name, device_type)
 
-Create an application.
+Create an application. This function only works if you log in using credentials or Auth Token.
 
 #### Args:
     name (str): application name.
@@ -60,7 +60,7 @@ Get all applications.
     list: list contains info of applications.
 ### Function: get_api_key(name)
 
-Get the API key for a specific application.
+Get the API key for a specific application. This function only works if you log in using credentials or Auth Token.
 
 #### Args:
     name (str): application name.
@@ -99,13 +99,13 @@ Check if the user has any applications.
     bool: True if user has any applications, False otherwise.
 ### Function: remove(name)
 
-Remove application.
+Remove application. This function only works if you log in using credentials or Auth Token.
 
 #### Args:
     name (str): application name.
 ### Function: restart(name)
 
-Restart application.
+Restart application. This function only works if you log in using credentials or Auth Token.
 
 #### Args:
     name (str): application name.
@@ -115,6 +115,24 @@ Restart application.
 ## Device
 
 This class implements device model for Resin Python SDK.
+### Function: disable_device_url(uuid)
+
+Disable device url for a device.
+
+#### Args:
+    uuid (str): device uuid.
+
+#### Raises:
+    DeviceNotFound: if device couldn't be found.
+### Function: enable_device_url(uuid)
+
+Enable device url for a device.
+
+#### Args:
+    uuid (str): device uuid.
+
+#### Raises:
+    DeviceNotFound: if device couldn't be found.
 ### Function: generate_uuid()
 
 Generate a random device UUID.
@@ -181,6 +199,15 @@ Get device slug.
 
 #### Raises:
     InvalidDeviceType: if device type name is not supported.
+### Function: get_device_url(uuid)
+
+Get a device url for a device.
+
+#### Args:
+    uuid (str): device uuid.
+
+#### Raises:
+    DeviceNotFound: if device couldn't be found.
 ### Function: get_display_name(device_type_slug)
 
 Get display name for a device.
@@ -254,9 +281,18 @@ Check if a device exists.
 
 #### Returns:
     bool: True if device exists, False otherwise.
+### Function: has_device_url(uuid)
+
+Check if a device is web accessible with device urls
+
+#### Args:
+    uuid (str): device uuid.
+
+#### Raises:
+    DeviceNotFound: if device couldn't be found.
 ### Function: identify(uuid)
 
-Identify device.
+Identify device. This function only works if you log in using credentials or Auth Token.
 
 #### Args:
     uuid (str): device uuid.
@@ -284,7 +320,7 @@ Note a device.
     DeviceNotFound: if device couldn't be found.
 ### Function: register(app_name, uuid)
 
-Register a new device with a Resin.io application.
+Register a new device with a Resin.io application. This function only works if you log in using credentials or Auth Token.
 
 #### Args:
     app_name (str): application name.
@@ -294,7 +330,7 @@ Register a new device with a Resin.io application.
     dict: dictionary contains device info.
 ### Function: remove(uuid)
 
-Remove a device.
+Remove a device. This function only works if you log in using credentials or Auth Token.
 
 #### Args:
     uuid (str): device uuid.
@@ -305,6 +341,15 @@ Rename a device.
 #### Args:
     uuid (str): device uuid.
     new_name (str): device new name.
+
+#### Raises:
+    DeviceNotFound: if device couldn't be found.
+### Function: restart(uuid)
+
+Restart a device. This function only works if you log in using credentials or Auth Token.
+
+#### Args:
+    uuid (str): device uuid.
 
 #### Raises:
     DeviceNotFound: if device couldn't be found.
@@ -326,18 +371,12 @@ Get device types configuration.
 
 #### Returns:
     list: device types information.
-### Function: get_pubnub_keys()
-
-Get PubNub keys from configuration.
-
-#### Returns:
-    dict: including PubNub subscribe_key and publish_key.
 ## DeviceOs
 
 This class implements device os model for Resin Python SDK.
 ### Function: download(raw)
 
-Download an OS image.
+Download an OS image. This function only works if you log in using credentials or Auth Token.
 
 #### Args:
     raw (bool): determining function return value.
@@ -364,7 +403,6 @@ Validate parameters for downloading device OS image.
     Raise:
         MissingOption: if mandatory option are missing.
         InvalidOption: if appId or network are invalid (appId is not a number or parseable string. network is not in NETWORK_TYPES)
-        NonAllowedOption: if a non supported option is passed.
 ## EnvironmentVariable
 
 This class is a wrapper for device and application environment variable models.
@@ -458,7 +496,7 @@ Update a device environment variable.
 This class implements ssh key model for Resin Python SDK.
 ### Function: create(title, key)
 
-Create a ssh key.
+Create a ssh key. This function only works if you log in using credentials or Auth Token.
 
 #### Args:
     title (str): key title.
@@ -486,7 +524,7 @@ Get all ssh keys.
     list: list of ssh keys.
 ### Function: remove(id)
 
-Remove a ssh key.
+Remove a ssh key. This function only works if you log in using credentials or Auth Token.
 
 #### Args:
     id (str): key id.
@@ -525,7 +563,7 @@ This function retrieves Auth Token.
     str: Auth Token.
 
 #### Raises:
-    InvalidOption: if not logged in and there is no token in Settings. 
+    InvalidOption: if not logged in and there is no token in Settings.
 ### Function: get_user_id()
 
 This function retrieves current logged in user's id.
@@ -537,7 +575,7 @@ This function retrieves current logged in user's id.
     InvalidOption: if not logged in.
 ### Function: is_logged_in()
 
-This function checks if you're logged in 
+This function checks if you're logged in
 
 #### Returns:
     bool: True if logged in, False otherwise.

--- a/resin/__init__.py
+++ b/resin/__init__.py
@@ -6,6 +6,7 @@ If you feel something is missing, not clear or could be improved, please don't
 hesitate to open an issue in GitHub, we'll be happy to help.
 """
 
+__version__ = '1.1.0'
 
 from .base_request import BaseRequest
 from .auth import Auth

--- a/resin/__init__.py
+++ b/resin/__init__.py
@@ -6,14 +6,15 @@ If you feel something is missing, not clear or could be improved, please don't
 hesitate to open an issue in GitHub, we'll be happy to help.
 """
 
-__version__ = '1.1.0'
-
 from .base_request import BaseRequest
 from .auth import Auth
 from .token import Token
 from .logs import Logs
 from .settings import Settings
 from .models import Models
+
+
+__version__ = '1.1.0'
 
 
 class Resin(object):

--- a/resin/auth.py
+++ b/resin/auth.py
@@ -105,7 +105,9 @@ class Auth(object):
 
         """
 
-        return self.token.has()
+        return self.base_request.request(
+            '/whoami', 'GET', endpoint=self.settings.get('api_endpoint')
+        )
 
     def get_token(self):
         """

--- a/resin/base_request.py
+++ b/resin/base_request.py
@@ -72,11 +72,9 @@ class BaseRequest(object):
                 query_template = Template("$$filter=$filter%20eq%20'$eq'")
             else:
                 query_template = Template("")
-            #if 'apikey' in params:
             query_elements.append(query_template.safe_substitute(params))
         if query_elements:
             return '?{0}'.format('&'.join(query_elements))
-
 
     def __request(self, url, method, params, endpoint, headers=None,
                   data=None, stream=None, auth=True, api_key=None):
@@ -123,12 +121,12 @@ class BaseRequest(object):
             params = self._format_params(params, api_key=api_key)
         else:
             params = self._format_params(params, api_key=None)
-        
+
         url = urljoin(url, params)
         return request_method(url, headers=headers, data=data, stream=stream)
 
     def request(self, url, method, endpoint, params=None, data=None,
-                stream=None, auth=True, login= False):
+                stream=None, auth=True, login=False):
         api_key = self.util.get_api_key()
 
         # Some requests require logging in using credentials or Auth Token to process

--- a/resin/exceptions.py
+++ b/resin/exceptions.py
@@ -199,6 +199,7 @@ class NotLoggedIn(Exception):
         self.exit_code = 1
         self.message = Message.NOT_LOGGED_IN
 
+
 class Unauthorized(Exception):
     """
     Exception when no user logged in and no Resin API Key provided.
@@ -251,6 +252,7 @@ class DeviceOffline(Exception):
         self.code = 'DeviceOffline'
         self.exit_code = 1
         self.message = Message.DEVICE_OFFLINE.format(uuid=uuid)
+
 
 class DeviceNotWebAccessible(Exception):
     """

--- a/resin/exceptions.py
+++ b/resin/exceptions.py
@@ -137,10 +137,10 @@ class DeviceNotFound(Exception):
 
     """
 
-    def __init__(self):
+    def __init__(self, uuid):
         self.code = 'DeviceNotFound'
         self.exit_code = 1
-        self.message = Message.DEVICE_NOT_FOUND.format(device=device)
+        self.message = Message.DEVICE_NOT_FOUND.format(uuid=uuid)
 
 
 class KeyNotFound(Exception):
@@ -199,6 +199,22 @@ class NotLoggedIn(Exception):
         self.exit_code = 1
         self.message = Message.NOT_LOGGED_IN
 
+class Unauthorized(Exception):
+    """
+    Exception when no user logged in and no Resin API Key provided.
+
+    Attributes:
+        code (str): exception code.
+        exit_code (int): program exit code.
+        message (str): error message.
+
+    """
+
+    def __init__(self):
+        self.code = 'Unauthorized'
+        self.exit_code = 1
+        self.message = Message.UNAUTHORIZED
+
 
 class LoginFailed(Exception):
     """
@@ -235,3 +251,22 @@ class DeviceOffline(Exception):
         self.code = 'DeviceOffline'
         self.exit_code = 1
         self.message = Message.DEVICE_OFFLINE.format(uuid=uuid)
+
+class DeviceNotWebAccessible(Exception):
+    """
+    Exception when a device is not web accessible.
+
+    Args:
+        uuid (str): device uuid.
+
+    Attributes:
+        code (str): exception code.
+        exit_code (int): program exit code.
+        message (str): error message.
+
+    """
+
+    def __init__(self, uuid):
+        self.code = 'DeviceNotWebAccessible'
+        self.exit_code = 1
+        self.message = Message.DEVICE_NOT_WEB_ACCESSIBLE.format(uuid=uuid)

--- a/resin/logs.py
+++ b/resin/logs.py
@@ -22,7 +22,7 @@ class Logs(object):
         @wraps(func)
         def wrapper(self, *args, **kwargs):
             if not hasattr(self, 'pubnub'):
-                pubnub_key = self.config.get_pubnub_keys()
+                pubnub_key = self.config.get_all()['pubnub']
                 self.pubnub = Pubnub(
                     publish_key=pubnub_key['publish_key'],
                     subscribe_key=pubnub_key['subscribe_key']

--- a/resin/models/application.py
+++ b/resin/models/application.py
@@ -120,7 +120,7 @@ class Application(object):
 
     def create(self, name, device_type):
         """
-        Create an application.
+        Create an application. This function only works if you log in using credentials or Auth Token.
 
         Args:
             name (str): application name.
@@ -144,14 +144,14 @@ class Application(object):
             }
             return self.base_request.request(
                 'application', 'POST', data=data,
-                endpoint=self.settings.get('pine_endpoint')
+                endpoint=self.settings.get('pine_endpoint'), login=True
             )
         else:
             raise exceptions.InvalidDeviceType(device_type)
 
     def remove(self, name):
         """
-        Remove application.
+        Remove application. This function only works if you log in using credentials or Auth Token.
 
         Args:
             name (str): application name.
@@ -164,12 +164,12 @@ class Application(object):
         }
         return self.base_request.request(
             'application', 'DELETE', params=params,
-            endpoint=self.settings.get('pine_endpoint')
+            endpoint=self.settings.get('pine_endpoint'), login=True
         )
 
     def restart(self, name):
         """
-        Restart application.
+        Restart application. This function only works if you log in using credentials or Auth Token.
 
         Args:
             name (str): application name.
@@ -181,13 +181,13 @@ class Application(object):
 
         app = self.get(name)
         return self.base_request.request(
-            '/application/{0}/restart'.format(app['id']), 'POST',
-            endpoint=self.settings.get('pine_endpoint')
+            'application/{0}/restart'.format(app['id']), 'POST',
+            endpoint=self.settings.get('api_endpoint'), login=True
         )
 
     def get_api_key(self, name):
         """
-        Get the API key for a specific application.
+        Get the API key for a specific application. This function only works if you log in using credentials or Auth Token.
 
         Args:
             name (str): application name.
@@ -202,6 +202,6 @@ class Application(object):
 
         app = self.get(name)
         return self.base_request.request(
-            '/application/{0}/generate-api-key'.format(app['id']), 'POST',
-            endpoint=self.settings.get('pine_endpoint')
+            'application/{0}/generate-api-key'.format(app['id']), 'POST',
+            endpoint=self.settings.get('api_endpoint'), login=True
         )

--- a/resin/models/config.py
+++ b/resin/models/config.py
@@ -36,19 +36,8 @@ class Config(object):
 
         if self._config is None:
             self._config = self.base_request.request(
-                '/config', 'GET', endpoint=self.settings.get('pine_endpoint'))
+                'config', 'GET', endpoint=self.settings.get('api_endpoint'))
         return self._config
-
-    def get_pubnub_keys(self):
-        """
-        Get PubNub keys from configuration.
-
-        Returns:
-            dict: including PubNub subscribe_key and publish_key.
-
-        """
-
-        return self._get_config('pubnub')
 
     def get_device_types(self):
         """

--- a/resin/models/device.py
+++ b/resin/models/device.py
@@ -532,11 +532,11 @@ class Device(object):
             raise exceptions.DeviceNotFound(uuid)
 
         params = {
-                'filter': 'uuid',
-                'eq': uuid
-            }
+            'filter': 'uuid',
+            'eq': uuid
+        }
         data = {
-                'is_web_accessible': True
+            'is_web_accessible': True
         }
 
         return self.base_request.request(

--- a/resin/models/device.py
+++ b/resin/models/device.py
@@ -225,7 +225,7 @@ class Device(object):
 
     def remove(self, uuid):
         """
-        Remove a device.
+        Remove a device. This function only works if you log in using credentials or Auth Token.
 
         Args:
             uuid (str): device uuid.
@@ -238,12 +238,12 @@ class Device(object):
         }
         return self.base_request.request(
             'device', 'DELETE', params=params,
-            endpoint=self.settings.get('pine_endpoint')
+            endpoint=self.settings.get('pine_endpoint'), login=True
         )
 
     def identify(self, uuid):
         """
-        Identify device.
+        Identify device. This function only works if you log in using credentials or Auth Token.
 
         Args:
             uuid (str): device uuid.
@@ -254,8 +254,8 @@ class Device(object):
             'uuid': uuid
         }
         return self.base_request.request(
-            '/blink', 'POST', data=data,
-            endpoint=self.settings.get('pine_endpoint')
+            'blink', 'POST', data=data,
+            endpoint=self.settings.get('api_endpoint'), login=True
         )
 
     def rename(self, uuid, new_name):
@@ -431,7 +431,7 @@ class Device(object):
 
     def register(self, app_name, uuid):
         """
-        Register a new device with a Resin.io application.
+        Register a new device with a Resin.io application. This function only works if you log in using credentials or Auth Token.
 
         Args:
             app_name (str): application name.
@@ -445,8 +445,8 @@ class Device(object):
         user_id = self.token.get_user_id()
         application = self.application.get(app_name)
         api_key = self.base_request.request(
-            '/application/{0}/generate-api-key'.format(application['id']),
-            'POST', endpoint=self.settings.get('pine_endpoint')
+            'application/{0}/generate-api-key'.format(application['id']),
+            'POST', endpoint=self.settings.get('api_endpoint'), login=True
         )
 
         now = (datetime.utcnow() - datetime.utcfromtimestamp(0))
@@ -464,5 +464,110 @@ class Device(object):
 
         return self.base_request.request(
             'device', 'POST', data=data,
+            endpoint=self.settings.get('pine_endpoint'), login=True
+        )
+
+    def restart(self, uuid):
+        """
+        Restart a device. This function only works if you log in using credentials or Auth Token.
+
+        Args:
+            uuid (str): device uuid.
+
+        Raises:
+            DeviceNotFound: if device couldn't be found.
+
+        """
+
+        device = self.get(uuid)
+        return self.base_request.request(
+            'device/{0}/restart'.format(device['id']),
+            'POST', endpoint=self.settings.get('api_endpoint'), login=True
+        )
+
+    def has_device_url(self, uuid):
+        """
+        Check if a device is web accessible with device urls
+
+        Args:
+            uuid (str): device uuid.
+
+        Raises:
+            DeviceNotFound: if device couldn't be found.
+
+        """
+
+        return self.get(uuid)['is_web_accessible']
+
+    def get_device_url(self, uuid):
+        """
+        Get a device url for a device.
+
+        Args:
+            uuid (str): device uuid.
+
+        Raises:
+            DeviceNotFound: if device couldn't be found.
+
+        """
+        if not self.has_device_url:
+            raise exceptions.DeviceNotWebAccessible(uuid)
+
+        device_url_base = self.config.get_all()['deviceUrlsBase']
+        return 'https://{uuid}.{base_url}'.format(uuid=uuid, base_url=device_url_base)
+
+    def enable_device_url(self, uuid):
+        """
+        Enable device url for a device.
+
+        Args:
+            uuid (str): device uuid.
+
+        Raises:
+            DeviceNotFound: if device couldn't be found.
+
+        """
+
+        if not self.has(uuid):
+            raise exceptions.DeviceNotFound(uuid)
+
+        params = {
+                'filter': 'uuid',
+                'eq': uuid
+            }
+        data = {
+                'is_web_accessible': True
+        }
+
+        return self.base_request.request(
+            'device', 'PATCH', params=params, data=data,
+            endpoint=self.settings.get('pine_endpoint')
+        )
+
+    def disable_device_url(self, uuid):
+        """
+        Disable device url for a device.
+
+        Args:
+            uuid (str): device uuid.
+
+        Raises:
+            DeviceNotFound: if device couldn't be found.
+
+        """
+
+        if not self.has(uuid):
+            raise exceptions.DeviceNotFound(uuid)
+
+        params = {
+            'filter': 'uuid',
+            'eq': uuid
+        }
+        data = {
+            'is_web_accessible': False
+        }
+
+        return self.base_request.request(
+            'device', 'PATCH', params=params, data=data,
             endpoint=self.settings.get('pine_endpoint')
         )

--- a/resin/models/device_os.py
+++ b/resin/models/device_os.py
@@ -13,15 +13,6 @@ NETWORK_TYPES = [
     NETWORK_ETHERNET
 ]
 
-VALID_OPTIONS = [
-    'network',
-    'appId',
-    'wifiSsid',
-    'wifiKey',
-    'appUpdatePollInterval'
-]
-
-
 class DeviceOs(object):
     """
     This class implements device os model for Resin Python SDK.
@@ -34,7 +25,7 @@ class DeviceOs(object):
 
     def download(self, raw=None, **data):
         """
-        Download an OS image.
+        Download an OS image. This function only works if you log in using credentials or Auth Token.
 
         Args:
             raw (bool): determining function return value.
@@ -54,7 +45,7 @@ class DeviceOs(object):
         self.params = self.parse_params(**data)
         response = self.base_request.request(
             'download', 'POST', data=data,
-            endpoint=self.settings.get('api_endpoint'), stream=True
+            endpoint=self.settings.get('api_endpoint'), stream=True, login=True
         )
         if raw:
             # return urllib3.HTTPResponse object
@@ -75,7 +66,6 @@ class DeviceOs(object):
             Raise:
                 MissingOption: if mandatory option are missing.
                 InvalidOption: if appId or network are invalid (appId is not a number or parseable string. network is not in NETWORK_TYPES)
-                NonAllowedOption: if a non supported option is passed.
 
         """
 
@@ -99,9 +89,5 @@ class DeviceOs(object):
 
             # if 'wifiKey' not in params:
             #    raise exceptions.MissingOption('wifiKey')
-
-        invalid_params = Set(params).difference(Set(VALID_OPTIONS))
-        if invalid_params:
-            raise exceptions.NonAllowedOption(list(invalid_params))
 
         return params

--- a/resin/models/device_os.py
+++ b/resin/models/device_os.py
@@ -13,6 +13,7 @@ NETWORK_TYPES = [
     NETWORK_ETHERNET
 ]
 
+
 class DeviceOs(object):
     """
     This class implements device os model for Resin Python SDK.

--- a/resin/models/key.py
+++ b/resin/models/key.py
@@ -60,7 +60,7 @@ class Key(object):
 
     def remove(self, id):
         """
-        Remove a ssh key.
+        Remove a ssh key. This function only works if you log in using credentials or Auth Token.
 
         Args:
             id (str): key id.
@@ -73,12 +73,12 @@ class Key(object):
         }
         return self.base_request.request(
             'user__has__public_key', 'DELETE', params=params,
-            endpoint=self.settings.get('pine_endpoint')
+            endpoint=self.settings.get('pine_endpoint'), login=True
         )
 
     def create(self, title, key):
         """
-        Create a ssh key.
+        Create a ssh key. This function only works if you log in using credentials or Auth Token.
 
         Args:
             title (str): key title.
@@ -99,6 +99,6 @@ class Key(object):
         }
         key = self.base_request.request(
             'user__has__public_key', 'POST', data=data,
-            endpoint=self.settings.get('pine_endpoint')
+            endpoint=self.settings.get('pine_endpoint'), login=True
         )
         return json.loads(key)['id']

--- a/resin/resources.py
+++ b/resin/resources.py
@@ -9,10 +9,11 @@ class Message(object):
     """
 
     # Exception Error Message
-    NOT_LOGGED_IN = "You have to log in"
+    NOT_LOGGED_IN = "You have to log in!"
+    UNAUTHORIZED = "You have to log in or RESIN_API_KEY environment variable must be set!"
     REQUEST_ERROR = "Request error: {body}"
     KEY_NOT_FOUND = "Key not found: {key}"
-    DEVICE_NOT_FOUND = "Device not found: {device}"
+    DEVICE_NOT_FOUND = "Device not found: {uuid}"
     APPLICATION_NOT_FOUND = "Application not found: {application}"
     MALFORMED_TOKEN = "Malformed token: {token}"
     INVALID_DEVICE_TYPE = "Invalid device type: {dev_type}"
@@ -21,3 +22,4 @@ class Message(object):
     NON_ALLOWED_OPTION = "Non allowed option: {option}"
     LOGIN_FAILED = "Invalid credentials"
     DEVICE_OFFLINE = "Device is offline: {uuid}"
+    DEVICE_NOT_WEB_ACCESSIBLE = "Device is not web accessible: {uuid}"

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,15 @@ https://github.com/pypa/sampleproject
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
 
+import resin
+
 setup(
     name='resin-sdk',
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.3',
+    version=resin.__version__,
 
     description='Resin.io SDK for Python',
 


### PR DESCRIPTION
### Added
- Implement Resin API Key. User can authorize by credentials, auth token or set Resin API key as RESIN_API_KEY environment variable.
- Implement `resin.models.device.restart()`
- Implement `resin.models.device.has_device_url()`
- Implement `resin.models.device.get_device_url()`
- Implement `resin.models.device.enable_device_url()`
- Implement `resin.models.device.disable_device_url()`
### Changed
- Fix `resin.auth.is_logged_in()` remove auth token.
- Fix bug with API endpoints in some functions.
- Implement `login` flag that marks functions only work if users authorize by credentials or auth token.
### Removed
- Remove `VALID_OPTIONS` in resin.models.device_os that blocks extra os parameters when downloading an image.
- Remove `resin.models.config.get_pubnub_keys()`.
