### PR TITLE
print invalid settings error message to STDERR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Changed
+
+- Output error messages to STDERR
+
 ## [1.5.1] - 2016-07-05
 
 ## Changed

--- a/resin/settings.py
+++ b/resin/settings.py
@@ -2,6 +2,7 @@ import ConfigParser
 import os.path as Path
 import os
 import shutil
+import sys
 
 from . import exceptions
 from .resources import Message
@@ -52,7 +53,7 @@ class Settings(object):
             except OSError:
                 pass
             self.__write_settings()
-            print(Message.INVALID_SETTINGS.format(path=config_file_path))
+            print(Message.INVALID_SETTINGS.format(path=config_file_path), file=sys.stderr)
 
     def __write_settings(self):
         config = ConfigParser.ConfigParser()


### PR DESCRIPTION
One possible solution is this, the minimum amount of change to fix things up, related to #33 

An alternative is to completely hide this message, as the problem it reports is actually fixed by the code preceding it, so it just has a little informational value, but no practical effect, if I understand correctly.
