### PR TITLE
Fix #46, Fix issue with auth.is_logged_in() raises Unauthorized exception.

### DIFF
--- a/resin/auth.py
+++ b/resin/auth.py
@@ -139,7 +139,7 @@ class Auth(object):
                 '/whoami', 'GET', endpoint=self.settings.get('api_endpoint')
             )
             return True
-        except exceptions.RequestError:
+        except (exceptions.RequestError, exceptions.Unauthorized):
             return False
 
     def get_token(self):


### PR DESCRIPTION
Since the request builder class checks the token before sending request, we need to add unauthorized exception here to handle the case when there is no auth token.