### PR TITLE
Add Python 3 support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 test.py
+*.py.bak

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.5"
+  - "3.6"
 # command to install dependencies
 install: "pip install pep8"
 # command to run tests

--- a/resin/auth.py
+++ b/resin/auth.py
@@ -39,7 +39,7 @@ class Auth(object):
 
         """
 
-        token = self.authenticate(**credentials)
+        token = self.authenticate(**credentials).decode("utf-8")
         if self.token.is_valid_token(token):
             self.token.set(token)
         else:

--- a/resin/base_request.py
+++ b/resin/base_request.py
@@ -1,10 +1,12 @@
-import requests
+try:  # Python 3 imports
+    from urllib.parse import urljoin
+except ImportError:  # Python 2 imports
+    from urlparse import urljoin
+
 import json
-import urllib
 from string import Template
 import os
-
-from urlparse import urljoin
+import requests
 
 from .settings import Settings
 from .token import Token
@@ -41,9 +43,8 @@ class BaseRequest(object):
         self.__set_content_type(headers, 'application/json')
         if not stream:
             return requests.post(url, data=json.dumps(data), headers=headers)
-        else:
-            return requests.post(
-                url, data=json.dumps(data), headers=headers, stream=stream)
+        return requests.post(
+            url, data=json.dumps(data), headers=headers, stream=stream)
 
     def __put(self, url, headers, data=None, stream=None):
         self.__set_content_type(headers, 'application/json')
@@ -105,7 +106,7 @@ class BaseRequest(object):
 
         headers = headers or {}
 
-        METHODS = {
+        methods = {
             'get': self.__get,
             'post': self.__post,
             'put': self.__put,
@@ -113,7 +114,7 @@ class BaseRequest(object):
             'head': self.__head,
             'patch': self.__patch
         }
-        request_method = METHODS[method.lower()]
+        request_method = methods[method.lower()]
         url = urljoin(endpoint, url)
         if auth:
             if not api_key:
@@ -170,11 +171,11 @@ class BaseRequest(object):
             raise exceptions.RequestError(response._content)
 
         try:
-            json = response.json()
+            json_data = response.json()
         except ValueError:
             return response.content
 
-        return json
+        return json_data
 
     def _request_new_token(self):
         headers = {}

--- a/resin/exceptions.py
+++ b/resin/exceptions.py
@@ -2,7 +2,22 @@
 from .resources import Message
 
 
-class MissingOption(Exception):
+class ResinException(Exception):
+    """
+    Exception base class for Python SDK.
+
+    Attributes:
+        code (str): exception code.
+        exit_code (int): program exit code.
+
+    """
+
+    def __init__(self):
+        self.code = self.__class__.__name__
+        self.exit_code = 1
+
+
+class MissingOption(ResinException):
     """
     Exception type for missing option in settings or auth token.
 
@@ -10,19 +25,16 @@ class MissingOption(Exception):
         option (str): option name.
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
     def __init__(self, option):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(MissingOption, self).__init__()
         self.message = Message.MISSING_OPTION.format(option=option)
 
 
-class InvalidOption(Exception):
+class InvalidOption(ResinException):
     """
     Exception type for invalid option in settings or auth token.
 
@@ -30,19 +42,16 @@ class InvalidOption(Exception):
         option (str): option name.
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
     def __init__(self, option):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(InvalidOption, self).__init__()
         self.message = Message.INVALID_OPTION.format(option=option)
 
 
-class NonAllowedOption(Exception):
+class NonAllowedOption(ResinException):
     """
     Exception type for non allowed option in parameters for downloading device OS.
 
@@ -50,19 +59,16 @@ class NonAllowedOption(Exception):
         option (str): option name.
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
     def __init__(self, option):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
-        self.message = Message.NON_ALLOWED_OPTION(option=option)
+        super(NonAllowedOption, self).__init__()
+        self.message = Message.NON_ALLOWED_OPTION.format(option=option)
 
 
-class InvalidDeviceType(Exception):
+class InvalidDeviceType(ResinException):
     """
     Exception type for invalid device type.
 
@@ -70,19 +76,16 @@ class InvalidDeviceType(Exception):
         dev_type (str): device type.
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
     def __init__(self, dev_type):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(InvalidDeviceType, self).__init__()
         self.message = Message.INVALID_DEVICE_TYPE.format(dev_type=dev_type)
 
 
-class MalformedToken(Exception):
+class MalformedToken(ResinException):
     """
     Exception type for malformed token.
 
@@ -90,19 +93,16 @@ class MalformedToken(Exception):
         token (str): token.
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
     def __init__(self, token):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(MalformedToken, self).__init__()
         self.message = Message.MALFORMED_TOKEN.format(token=token)
 
 
-class ApplicationNotFound(Exception):
+class ApplicationNotFound(ResinException):
     """
     Exception type for application not found.
 
@@ -110,20 +110,17 @@ class ApplicationNotFound(Exception):
         application (str): application detail (application name or id).
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
     def __init__(self, application):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(ApplicationNotFound, self).__init__()
         self.message = Message.APPLICATION_NOT_FOUND.format(
             application=application)
 
 
-class DeviceNotFound(Exception):
+class DeviceNotFound(ResinException):
     """
     Exception type for device not found.
 
@@ -131,19 +128,16 @@ class DeviceNotFound(Exception):
         device (str): device detail (device uuid or device name).
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
     def __init__(self, uuid):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(DeviceNotFound, self).__init__()
         self.message = Message.DEVICE_NOT_FOUND.format(uuid=uuid)
 
 
-class KeyNotFound(Exception):
+class KeyNotFound(ResinException):
     """
     Exception type for ssh key not found.
 
@@ -151,19 +145,16 @@ class KeyNotFound(Exception):
         key (str): ssh key id.
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
     def __init__(self, key):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(KeyNotFound, self).__init__()
         self.message = Message.KEY_NOT_FOUND.format(key=key)
 
 
-class RequestError(Exception):
+class RequestError(ResinException):
     """
     Exception type for request error.
 
@@ -171,53 +162,44 @@ class RequestError(Exception):
         body (str): response body.
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
     def __init__(self, body):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(RequestError, self).__init__()
         self.message = Message.REQUEST_ERROR.format(body=body)
 
 
-class NotLoggedIn(Exception):
+class NotLoggedIn(ResinException):
     """
     Exception when no user logged in.
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
     def __init__(self):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(NotLoggedIn, self).__init__()
         self.message = Message.NOT_LOGGED_IN
 
 
-class Unauthorized(Exception):
+class Unauthorized(ResinException):
     """
     Exception when no user logged in and no Resin API Key provided.
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
     def __init__(self):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(Unauthorized, self).__init__()
         self.message = Message.UNAUTHORIZED
 
 
-class LoginFailed(Exception):
+class LoginFailed(ResinException):
     """
     Exception when login unsuccessful.
 
@@ -229,12 +211,11 @@ class LoginFailed(Exception):
     """
 
     def __init__(self):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(LoginFailed, self).__init__()
         self.message = Message.LOGIN_FAILED
 
 
-class DeviceOffline(Exception):
+class DeviceOffline(ResinException):
     """
     Exception when a device is offline.
 
@@ -242,19 +223,16 @@ class DeviceOffline(Exception):
         uuid (str): device uuid.
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
     def __init__(self, uuid):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(DeviceOffline, self).__init__()
         self.message = Message.DEVICE_OFFLINE.format(uuid=uuid)
 
 
-class DeviceNotWebAccessible(Exception):
+class DeviceNotWebAccessible(ResinException):
     """
     Exception when a device is not web accessible.
 
@@ -262,19 +240,16 @@ class DeviceNotWebAccessible(Exception):
         uuid (str): device uuid.
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
     def __init__(self, uuid):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(DeviceNotWebAccessible, self).__init__()
         self.message = Message.DEVICE_NOT_WEB_ACCESSIBLE.format(uuid=uuid)
 
 
-class IncompatibleApplication(Exception):
+class IncompatibleApplication(ResinException):
     """
     Exception when moving a device to an application with different device-type.
 
@@ -282,19 +257,16 @@ class IncompatibleApplication(Exception):
         application (str): application name.
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
     def __init__(self, application):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(IncompatibleApplication, self).__init__()
         self.message = Message.INCOMPATIBLE_APPLICATION.format(application=application)
 
 
-class UnsupportedFunction(Exception):
+class UnsupportedFunction(ResinException):
     """
     Exception when invoking an unsupported function in a specific supervisor version.
 
@@ -303,73 +275,61 @@ class UnsupportedFunction(Exception):
         current_version (str): current supervisor version.
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
     def __init__(self, required_version, current_version):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(UnsupportedFunction, self).__init__()
         self.message = Message.SUPERVISOR_VERSION_ERROR.format(req_version=required_version, cur_version=current_version)
 
 
-class AmbiguousApplication(Exception):
+class AmbiguousApplication(ResinException):
     """
     Args:
         application (str): application name.
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
     def __init__(self, application):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(AmbiguousApplication, self).__init__()
         self.message = Message.AMBIGUOUS_APPLICATION.format(application=application)
 
 
-class AmbiguousDevice(Exception):
+class AmbiguousDevice(ResinException):
     """
     Args:
         uuid (str): device uuid.
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
     def __init__(self, uuid):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(AmbiguousDevice, self).__init__()
         self.message = Message.AMBIGUOUS_DEVICE.format(uuid=uuid)
 
 
-class BuildNotFound(Exception):
+class BuildNotFound(ResinException):
     """
     Args:
-        id (str): build id.
+        build_id (str): build id.
 
     Attributes:
-        code (str): exception code.
-        exit_code (int): program exit code.
         message (str): error message.
 
     """
 
-    def __init__(self, id):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
-        self.message = Message.BUILD_NOT_FOUND.format(id=id)
+    def __init__(self, build_id):
+        super(BuildNotFound, self).__init__()
+        self.message = Message.BUILD_NOT_FOUND.format(id=build_id)
 
 
-class InvalidParameter(Exception):
+class InvalidParameter(ResinException):
     """
     Args:
         parameter (str): parameter name.
@@ -383,6 +343,5 @@ class InvalidParameter(Exception):
     """
 
     def __init__(self, parameter, value):
-        self.code = self.__class__.__name__
-        self.exit_code = 1
+        super(InvalidParameter, self).__init__()
         self.message = Message.INVALID_PARAMETER.format(parameter=parameter, value=value)

--- a/resin/models/config.py
+++ b/resin/models/config.py
@@ -53,7 +53,7 @@ class Config(object):
         if self._config is None:
             self._config = self.base_request.request(
                 'config', 'GET', endpoint=self.settings.get('api_endpoint'))
-            self._config['deviceTypes'] = map(_normalize_device_type, self._config['deviceTypes'])
+            self._config['deviceTypes'] = list(map(_normalize_device_type, self._config['deviceTypes']))
         return self._config
 
     def get_device_types(self):

--- a/resin/models/device.py
+++ b/resin/models/device.py
@@ -3,7 +3,10 @@ import binascii
 import os
 from datetime import datetime
 
-from urlparse import urljoin
+try:  # Python 3 imports
+    from urllib.parse import urljoin
+except ImportError:  # Python 2 imports
+    from urlparse import urljoin
 
 from ..base_request import BaseRequest
 from .config import Config
@@ -141,7 +144,7 @@ class Device(object):
 
         """
         params = {
-            'filter': 'application',
+            'filter': 'belongs_to__application',
             'eq': appid
         }
         return self.base_request.request(

--- a/resin/models/environment_variables.py
+++ b/resin/models/environment_variables.py
@@ -173,7 +173,7 @@ class DeviceEnvVariable(object):
         env_list = self.base_request.request(
             'device_environment_variable', 'GET', params=params,
             endpoint=self.settings.get('pine_endpoint'))
-        return map(self._fix_device_env_var_name_key, env_list['d'])
+        return list(map(self._fix_device_env_var_name_key, env_list['d']))
 
 
 class ApplicationEnvVariable(object):

--- a/resin/settings.py
+++ b/resin/settings.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 
-import ConfigParser
 import os.path as Path
 import os
 import shutil
@@ -8,6 +7,11 @@ import sys
 
 from . import exceptions
 from .resources import Message
+
+try:  # Python 3 imports
+    import configparser
+except ImportError:  # Python 2 imports
+    import ConfigParser as configparser
 
 
 class Settings(object):
@@ -30,14 +34,16 @@ class Settings(object):
                                 'token_refresh_interval', 'cache_directory'])
 
     _setting = {
+        # These are default config values to write default config file.
+        # All values here must be in string format otherwise there will be error when write config file.
         'pine_endpoint': 'https://api.resin.io/v3/',
         'api_endpoint': 'https://api.resin.io/',
         'api_version': 'v3',
         'data_directory': Path.join(HOME_DIRECTORY, '.resin'),
         # cache time : 1 week in milliseconds
-        'image_cache_time': (1 * 1000 * 60 * 60 * 24 * 7),
+        'image_cache_time': str(1 * 1000 * 60 * 60 * 24 * 7),
         # token refresh interval: 1 hour in milliseconds
-        'token_refresh_interval': (1 * 1000 * 60 * 60)
+        'token_refresh_interval': str(1 * 1000 * 60 * 60)
     }
 
     _setting['cache_directory'] = Path.join(_setting['data_directory'],
@@ -74,18 +80,18 @@ class Settings(object):
 
         if default:
             self._setting = Settings._setting
-        config = ConfigParser.ConfigParser()
+        config = configparser.ConfigParser()
         config.add_section(self.CONFIG_SECTION)
         for key in self._setting:
             config.set(self.CONFIG_SECTION, key, self._setting[key])
         if not Path.isdir(self._setting['data_directory']):
             os.makedirs(self._setting['data_directory'])
         with open(Path.join(self._setting['data_directory'],
-                            self.CONFIG_FILENAME), 'wb') as config_file:
+                            self.CONFIG_FILENAME), 'w') as config_file:
             config.write(config_file)
 
     def __read_settings(self):
-        config_reader = ConfigParser.ConfigParser()
+        config_reader = configparser.ConfigParser()
         config_reader.read(Path.join(self._setting['data_directory'],
                                      self.CONFIG_FILENAME))
         config_data = {}

--- a/resin/token.py
+++ b/resin/token.py
@@ -1,5 +1,5 @@
-import jwt
 from datetime import datetime
+import jwt
 
 from .settings import Settings
 from . import exceptions

--- a/resin/twofactor_auth.py
+++ b/resin/twofactor_auth.py
@@ -1,4 +1,7 @@
-import urlparse
+try:  # Python 3 imports
+    from urllib.parse import urlparse
+except ImportError:  # Python 2 imports
+    from urlparse import urlparse
 
 import pyotp
 

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 
     # What does your project relate to?

--- a/tests/pep8-git-pr-checker
+++ b/tests/pep8-git-pr-checker
@@ -18,7 +18,7 @@ def system(*args, **kwargs):
 
 def main():
     files = []
-    output = system('git', 'ls-files')
+    output = system('git', 'ls-files').decode("utf-8")
     for tmp_file in output.split():
         if tmp_file.endswith('.py'):
             files.append(tmp_file)
@@ -29,7 +29,7 @@ def main():
         filepath = os.path.dirname(filename)
         if not os.path.exists(filepath):
             os.makedirs(filepath)
-        with file(filename, 'w') as f:
+        with open(filename, 'w') as f:
             system('git', 'show', ':{0}'.format(name), stdout=f)
 
     args = ['pep8']


### PR DESCRIPTION
This PR contains some changes to make sure the right libraries and
dependencies are loaded to support Python 3. There is no big change in the source code since most
of the code is Python 3 compatible. Fixes #35 and #45.

Apart from that there are some improments and bug fixes included:
- Implement base class for resin exceptions.
- Fix a bug in `resin.models.device.get_all_by_application()` to make it
works with API v3.