### PR TITLE
Update device.set_to_build() to work with latest API.

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -761,21 +761,22 @@ Set a custom location for a device.
 >>> resin.models.device.set_custom_location('df09262c283b1dc1462d0e82caa7a88e52588b8c5d7475dd22210edec1c50a',location)
 OK
 ```
-### Function: set_to_build(uuid, build)
+### Function: set_to_build(uuid, build_commit_hash)
 
-Set a device to specific build id.
+Set a device to specific build commit hash.
 
 #### Args:
     uuid (str): device uuid.
-    build (str): build id.
+    build_commit_hash (str): build commit hash.
 
 #### Raises:
     DeviceNotFound: if device couldn't be found.
     ApplicationNotFound: if application couldn't be found.
+    FailedBuild: if build commit hash points to an error build.
     IncompatibleApplication: if moving a device to an application with different device-type.
 
 #### Examples:
-    >> > resin.models.device.set_to_build('8deb12a58e3b6d3920db1c2b6303d1ff32f23d5ab99781ce1dde6876e8d143', '123098')
+    >> > resin.models.device.set_to_build('4457d5db93be458270666ef8b8157c66', '950eac2d3efce555490c96e7c9b55c37b385acb6')
     'OK'
 ### Function: unset_custom_location(uuid)
 

--- a/resin/exceptions.py
+++ b/resin/exceptions.py
@@ -329,6 +329,21 @@ class BuildNotFound(ResinException):
         self.message = Message.BUILD_NOT_FOUND.format(id=build_id)
 
 
+class FailedBuild(ResinException):
+    """
+    Args:
+        build_id (str): build id.
+
+    Attributes:
+        message (str): error message.
+
+    """
+
+    def __init__(self, build_id):
+        super(FailedBuild, self).__init__()
+        self.message = Message.FAILED_BUILD.format(id=build_id)
+
+
 class InvalidParameter(ResinException):
     """
     Args:

--- a/resin/models/build.py
+++ b/resin/models/build.py
@@ -43,9 +43,28 @@ class Build(object):
         else:
             raise exceptions.BuildNotFound(id)
 
+    def get_by_commit(self, commit_hash):
+        """
+        Get a specific build by commit hash.
+        """
+
+        params = {
+            'filter': 'commit_hash',
+            'eq': commit_hash
+        }
+
+        build = self.base_request.request(
+            'build', 'GET', params=params,
+            endpoint=self.settings.get('pine_endpoint')
+        )
+        if build and (len(build['d']) > 0):
+            return build['d']
+        else:
+            raise exceptions.BuildNotFound(commit_hash)
+
     def get_all_by_application(self, app_id, include_logs=False):
         """
-        Get a specific build.
+        Get list of builds belong to an application.
 
         Args:
             app_id (str): application id.

--- a/resin/resources.py
+++ b/resin/resources.py
@@ -29,4 +29,5 @@ class Message(object):
     AMBIGUOUS_APPLICATION = "Application is ambiguous: {application}"
     AMBIGUOUS_DEVICE = "Device is ambiguous: {uuid}"
     BUILD_NOT_FOUND = "Build not found: {id}"
+    FAILED_BUILD = "Can not set to a failed build: {id}"
     INVALID_PARAMETER = "Invalid parameter: {value} is not a valid value for parameter `{parameter}`"


### PR DESCRIPTION
Change the argument from build id to build commit hash since build id is not available on the dashboard.