### PR TITLE
Print a deprecation warning message when using the unrenamed Python SDK

### DIFF
--- a/resin/__init__.py
+++ b/resin/__init__.py
@@ -35,6 +35,7 @@ from .settings import Settings
 from .models import Models
 from .twofactor_auth import TwoFactorAuth
 
+from .util.deprecation_warning import print_rename_warning
 
 __version__ = '5.1.2'
 
@@ -51,6 +52,8 @@ class Resin(object):
     """
 
     def __init__(self):
+        print_rename_warning()
+
         self.settings = Settings()
         self.logs = Logs()
         self.auth = Auth()

--- a/resin/util/deprecation_warning.py
+++ b/resin/util/deprecation_warning.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+import sys
+import textwrap
+
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+
+def run_once(f):
+    def wrapper(*args, **kwargs):
+        if not wrapper.has_run:
+            wrapper.has_run = True
+            return f(*args, **kwargs)
+    wrapper.has_run = False
+    return wrapper
+
+
+@run_once
+def print_rename_warning():
+    eprint(textwrap.dedent("""\
+        Warning: 'resin-sdk-python' is now 'balena-sdk-python'.
+        Please update your dependencies to continue receiving new updates.
+    """))


### PR DESCRIPTION
The Python SDK equivalent of https://github.com/resin-io/resin-sdk/pull/589.

This prints (one time maximum, to stderr) a deprecation warning. We can release this as a final resin-sdk-python release, so that anybody still installing this in future will get a warning.

We should not merge/publish this PR until the main rename is in PR, and ready to merge & release directly afterwards.

Tested in Python 3.6.6 and Python 2.7.15.

Fixes #112 
Change-type: patch
Signed-off-by: Tim Perry <tim@resin.io>