### PR TITLE
Allow overriding the test API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ To generate the documentation:
 python docs_generators.py > DOCUMENTATION.md
 ```
 
+Tests
+-----
+
+To run the tests, first create a `.env` file with your test user configuration, e.g.:
+
+```
+[Credentials]
+email=my_test_user@resin.io
+user_id=my_test_user
+password=123456my_password
+```
+
+Then run `python -m unittest discover tests -v`.
+
 Support
 -------
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ user_id=my_test_user
 password=123456my_password
 ```
 
+You can optionally change the target API endpoint too, e.g. `api_endpoint=https://api.resin.io`.
+
 Then run `python -m unittest discover tests -v`.
 
 Support

--- a/tests/functional/models/test_application.py
+++ b/tests/functional/models/test_application.py
@@ -27,7 +27,7 @@ class TestApplication(unittest.TestCase):
         # should be rejected if the name has less than four characters
         with self.assertRaises(Exception) as cm:
             self.resin.models.application.create('Fo', 'Raspberry Pi 2')
-        self.assertIn('It is necessary that each app name that is of an organization, has a Length (Type) that is greater than or equal to 4 and is less than or equal to 30.', cm.exception.message)
+        self.assertIn('It is necessary that each application has an app name that has a Length (Type) that is greater than or equal to 4 and is less than or equal to 30.', cm.exception.message)
 
         # should be able to create an application
         app = self.resin.models.application.create('FooBar', 'Raspberry Pi 2')

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -25,6 +25,11 @@ class TestHelper(object):
         self.resin_exceptions = resin_exceptions
         self.base_request = BaseRequest()
         self.settings = Settings()
+
+        if 'api_endpoint' in self.credentials and self.credentials['api_endpoint'] is not None:
+            self.settings.set('api_endpoint', self.credentials['api_endpoint'])
+            self.settings.set('pine_endpoint', '{0}/{1}/'.format(self.credentials['api_endpoint'], self.settings.get('api_version')))
+
         if not self.resin.auth.is_logged_in():
             self.resin.auth.login(
                 **{
@@ -41,7 +46,7 @@ class TestHelper(object):
     @classmethod
     def load_env(cls):
         env_file_name = '.env'
-        default_env_keys = set(['email', 'user_id', 'password'])
+        required_env_keys = set(['email', 'user_id', 'password'])
         cls.credentials = {}
 
         if Path.isfile(env_file_name):
@@ -55,7 +60,7 @@ class TestHelper(object):
                     config_data[option] = config_reader.get('Credentials', option)
                 except:
                     config_data[option] = None
-            if not default_env_keys.issubset(set(config_data)):
+            if not required_env_keys.issubset(set(config_data)):
                 raise Exception('Mandatory env keys missing!')
             cls.credentials = config_data
         else:
@@ -64,6 +69,9 @@ class TestHelper(object):
                 cls.credentials['email'] = os.environ['TEST_ENV_EMAIL']
                 cls.credentials['user_id'] = os.environ['TEST_ENV_USER_ID']
                 cls.credentials['password'] = os.environ['TEST_ENV_PASSWORD']
+
+                # Optional endpoint override:
+                cls.credentials['api_endpoint'] = os.environ.get('TEST_API_ENDPOINT')
             except:
                 raise Exception('Mandatory env keys missing!')
 


### PR DESCRIPTION
This is going to make it easier to start early testing against the new API, once that's available.

I've also added some docs, and fixed the app name test to work against the code currently on staging (it currently fails against prod due to a prod bug, but the fix that's on staging slightly changes the actual error message).

Fixes #115 