### PR TITLE
Balena Python SDK

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -212,6 +212,26 @@ Get a single application by application id.
 >>> balena.models.application.get_by_id(9020)
 {u'app_name': u'RPI1', u'__metadata': {u'type': u'', u'uri': u'/ewa/application(9020)'}, u'git_repository': u'g_trong_nghia_nguyen@git.balena.io:g_trong_nghia_nguyen/rpi1.git', u'user': {u'__deferred': {u'uri': u'/ewa/user(5397)'}, u'__id': 5397}, u'device_type': u'raspberry-pi', u'commit': None, u'id': 9020}
 ```
+### Function: get_by_owner(name, owner)
+
+Get a single application.
+
+#### Args:
+    name (str): application name.
+    owner (str):  owner's username.
+
+#### Returns:
+    dict: application info.
+
+#### Raises:
+    ApplicationNotFound: if application couldn't be found.
+    AmbiguousApplication: when more than one application is returned.
+
+#### Examples:
+```python
+>>> balena.models.application.get_by_owner('mothaiba', 'pythonsdk_test_resin')
+{u'depends_on__application': None, u'should_track_latest_release': True, u'app_name': u'mothaiba', u'application_type': {u'__deferred': {u'uri': u'/resin/application_type(5)'}, u'__id': 5}, u'__metadata': {u'type': u'', u'uri': u'/resin/application(1307755)'}, u'is_accessible_by_support_until__date': None, u'actor': 3438708, u'id': 1307755, u'user': {u'__deferred': {u'uri': u'/resin/user(32986)'}, u'__id': 32986}, u'device_type': u'raspberrypi3', u'commit': None, u'slug': u'pythonsdk_test_resin/mothaiba'}
+```
 ### Function: get_config(app_id)
 
         Download application config.json.
@@ -247,6 +267,20 @@ Tethering=false
 Enable=true
 Tethering=false'}, u'pubnubPublishKey': u'pub-c-6cbce8db-bfd1-4fdf-a8c8-53671ae2b226', u'apiEndpoint': u'https://api.balena.io', u'connectivity': u'connman', u'deviceType': u'raspberrypi3', u'mixpanelToken': u'11111111111111111111111111111111', u'deltaEndpoint': u'https://delta.balena.io', u'appUpdatePollInterval': 60000, u'applicationId': 106640, u'registryEndpoint': u'registry.balena.io'}
         
+### Function: get_target_release_hash(app_id)
+
+Get the hash of the current release for a specific application.
+
+#### Args:
+    app_id (str): application id.
+
+#### Returns:
+    str: The release hash of the current release.
+
+#### Examples:
+```python
+>>> balena.models.application.get_target_release_hash('5685')
+```
 ### Function: grant_support_access(app_id, expiry_timestamp)
 
 Grant support access to an application until a specified time.
@@ -288,6 +322,19 @@ Check if the user has any applications.
 >>> balena.models.application.has_any()
 True
 ```
+### Function: is_tracking_latest_release(app_id)
+
+Get whether the application is up to date and is tracking the latest release for updates.
+
+#### Args:
+    app_id (str): application id.
+
+#### Returns:
+    bool: is tracking the latest release.
+
+#### Examples:
+    >> > balena.models.application.is_tracking_latest_release('5685')
+    True
 ### Function: remove(name)
 
 Remove application. This function only works if you log in using credentials or Auth Token.
@@ -328,14 +375,13 @@ Revoke support access to an application.
 #### Examples:
     >> > balena.models.application.revoke_support_access('5685')
     'OK'
-### Function: set_to_release(app_id, commit_id)
+### Function: set_to_release(app_id, full_release_hash)
 
 Set an application to a specific commit.
-The commit will get updated on the next push unless rolling updates are disabled (there is a dedicated method for that which is balena.models.applicaion.disable_rolling_updates())
 
 #### Args:
     app_id (str): application id.
-    commit_id (str) : commit id.
+    full_release_hash (str) : full_release_hash.
 
 #### Returns:
     OK/error.
@@ -343,6 +389,30 @@ The commit will get updated on the next push unless rolling updates are disabled
 #### Examples:
     >> > balena.models.application.set_to_release('5685', '7dba4e0c461215374edad74a5b78f470b894b5b7')
     'OK'
+### Function: track_latest_release(app_id)
+
+Configure a specific application to track the latest available release.
+
+#### Args:
+    app_id (str): application id.
+
+#### Examples:
+```python
+>>> balena.models.application.track_latest_release('5685')
+```
+### Function: will_track_new_releases(app_id)
+
+Get whether the application is configured to receive updates whenever a new release is available.
+
+#### Args:
+    app_id (str): application id.
+
+#### Returns:
+    bool: is tracking the latest release.
+
+#### Examples:
+    >> > balena.models.application.will_track_new_releases('5685')
+    True
 ## ApiKey
 
 This class implements user API key model for balena python SDK.
@@ -946,6 +1016,18 @@ Check if a device is online.
 
 #### Raises:
     DeviceNotFound: if device couldn't be found.
+### Function: is_tracking_application_release(uuid)
+
+Get whether the device is configured to track the current application release.
+
+#### Args:
+    uuid (str): device uuid.
+
+#### Returns:
+    bool: is tracking the current application release.
+
+#### Raises:
+    DeviceNotFound: if device couldn't be found.
 ### Function: move(uuid, app_name)
 
 Move a device to another application.
@@ -1085,6 +1167,15 @@ Set an empty commit_id will restore rolling releases to the device.
 #### Examples:
     >> > balena.models.device.set_to_release('49b2a76b7f188c1d6f781e67c8f34adb4a7bfd2eec3f91d40b1efb75fe413d', '45c90004de73557ded7274d4896a6db90ea61e36')
     'OK'
+### Function: track_application_release(uuid)
+
+Configure a specific device to track the current application release.
+
+#### Args:
+    uuid (str): device uuid.
+
+#### Raises:
+    DeviceNotFound: if device couldn't be found.
 ### Function: unset_custom_location(uuid)
 
 clear custom location for a device.
@@ -1508,6 +1599,15 @@ Get all releases from an application.
 
 #### Returns:
     list: release info.
+### Function: get_latest_by_application(app_id)
+
+Get the latest successful release for an application.
+
+#### Args:
+    app_id (str): applicaiton id.
+
+#### Returns:
+    dict: release info.
 ### Function: get_with_image_details(id)
 
 Get a specific release with the details of the images built.

--- a/balena/models/application.py
+++ b/balena/models/application.py
@@ -40,10 +40,8 @@ class Application(object):
 
         """
 
-        raw_query = "$filter=(user eq '{user_id}') or (includes__user/any(x:x/user eq '{user_id}'))".format(user_id=self.auth.get_user_id())
-
         return self.base_request.request(
-            'application', 'GET', raw_query=raw_query, endpoint=self.settings.get('pine_endpoint')
+            'my_application', 'GET', endpoint=self.settings.get('pine_endpoint')
         )['d']
 
     def get(self, name):

--- a/balena/models/application.py
+++ b/balena/models/application.py
@@ -97,8 +97,8 @@ class Application(object):
             AmbiguousApplication: when more than one application is returned.
 
         Examples:
-            >>> balena.models.application.get('RPI1')
-            {u'app_name': u'RPI1', u'__metadata': {u'type': u'', u'uri': u'/ewa/application(9020)'}, u'git_repository': u'g_trong_nghia_nguyen@git.balena.io:g_trong_nghia_nguyen/rpi1.git', u'user': {u'__deferred': {u'uri': u'/ewa/user(5397)'}, u'__id': 5397}, u'device_type': u'raspberry-pi', u'commit': None, u'id': 9020}
+            >>> balena.models.application.get_by_owner('mothaiba', 'pythonsdk_test_resin')
+            {u'depends_on__application': None, u'should_track_latest_release': True, u'app_name': u'mothaiba', u'application_type': {u'__deferred': {u'uri': u'/resin/application_type(5)'}, u'__id': 5}, u'__metadata': {u'type': u'', u'uri': u'/resin/application(1307755)'}, u'is_accessible_by_support_until__date': None, u'actor': 3438708, u'id': 1307755, u'user': {u'__deferred': {u'uri': u'/resin/user(32986)'}, u'__id': 32986}, u'device_type': u'raspberrypi3', u'commit': None, u'slug': u'pythonsdk_test_resin/mothaiba'}
 
         """
 

--- a/balena/models/application.py
+++ b/balena/models/application.py
@@ -79,6 +79,44 @@ class Application(object):
         except IndexError:
             raise exceptions.ApplicationNotFound(name)
 
+    def get_by_owner(self, name, owner):
+        """
+        Get a single application.
+
+        Args:
+            name (str): application name.
+            owner (str):  owner's username.
+
+        Returns:
+            dict: application info.
+
+        Raises:
+            ApplicationNotFound: if application couldn't be found.
+            AmbiguousApplication: when more than one application is returned.
+
+        Examples:
+            >>> balena.models.application.get('RPI1')
+            {u'app_name': u'RPI1', u'__metadata': {u'type': u'', u'uri': u'/ewa/application(9020)'}, u'git_repository': u'g_trong_nghia_nguyen@git.balena.io:g_trong_nghia_nguyen/rpi1.git', u'user': {u'__deferred': {u'uri': u'/ewa/user(5397)'}, u'__id': 5397}, u'device_type': u'raspberry-pi', u'commit': None, u'id': 9020}
+
+        """
+
+        slug = '{owner}/{app_name}'.format(owner=owner.lower(), app_name=name.lower())
+
+        params = {
+            'filter': 'slug',
+            'eq': slug
+        }
+        try:
+            apps = self.base_request.request(
+                'application', 'GET', params=params,
+                endpoint=self.settings.get('pine_endpoint')
+            )['d']
+            if len(apps) > 1:
+                raise exceptions.AmbiguousApplication(slug)
+            return apps[0]
+        except IndexError:
+            raise exceptions.ApplicationNotFound(slug)
+
     def has(self, name):
         """
         Check if an application exists.

--- a/balena/models/config.py
+++ b/balena/models/config.py
@@ -28,7 +28,8 @@ class Config(object):
     def __init__(self):
         self.base_request = BaseRequest()
         self.settings = Settings()
-        self._config = None
+        self._config = {}
+        self._device_types = None
 
     def _get_config(self, key):
         if self._config:
@@ -50,10 +51,9 @@ class Config(object):
 
         """
 
-        if self._config is None:
+        if not self._config:
             self._config = self.base_request.request(
                 'config', 'GET', endpoint=self.settings.get('api_endpoint'))
-            self._config['deviceTypes'] = list(map(_normalize_device_type, self._config['deviceTypes']))
         return self._config
 
     def get_device_types(self):
@@ -69,4 +69,8 @@ class Config(object):
 
         """
 
-        return self._get_config('deviceTypes')
+        if not self._device_types:
+            self._device_types = self.base_request.request(
+                'device-types/v1', 'GET', endpoint=self.settings.get('api_endpoint'), auth=False)
+            self._device_types = list(map(_normalize_device_type, self._device_types))
+        return self._device_types

--- a/balena/models/device.py
+++ b/balena/models/device.py
@@ -1048,3 +1048,48 @@ class Device(object):
             'device', 'PATCH', params=params, data=data,
             endpoint=self.settings.get('pine_endpoint')
         )
+
+    def is_tracking_application_release(self, uuid):
+        """
+        Get whether the device is configured to track the current application release.
+
+        Args:
+            uuid (str): device uuid.
+
+        Returns:
+            bool: is tracking the current application release.
+
+        Raises:
+            DeviceNotFound: if device couldn't be found.
+
+        """
+
+        return not bool(self.get(uuid)['should_be_running__release'])
+
+    def track_application_release(self, uuid):
+        """
+        Configure a specific device to track the current application release.
+
+        Args:
+            uuid (str): device uuid.
+
+        Raises:
+            DeviceNotFound: if device couldn't be found.
+
+        """
+
+        device_id = self.get(uuid)['id']
+
+        params = {
+            'filter': 'id',
+            'eq': device_id
+        }
+
+        data = {
+            'should_be_running__release': None
+        }
+
+        return self.base_request.request(
+            'device', 'PATCH', params=params, data=data,
+            endpoint=self.settings.get('pine_endpoint')
+        )

--- a/balena/models/release.py
+++ b/balena/models/release.py
@@ -48,7 +48,32 @@ class Release(object):
         if release['d']:
             return release['d']
         else:
-            raise exceptions.ReleaseNotFound(key)
+            raise exceptions.ReleaseNotFound(value)
+
+    def __get_by_raw_query(self, raw_query):
+        """
+        Private function to get releases using raw query.
+
+        Args:
+            raw_query (str): query field.
+
+        Returns:
+            list: release info.
+
+        Raises:
+            ReleaseNotFound: if release couldn't be found.
+
+        """
+
+        release = self.base_request.request(
+            'release', 'GET', raw_query=raw_query,
+            endpoint=self.settings.get('pine_endpoint')
+        )
+
+        if release['d']:
+            return release['d']
+        else:
+            raise exceptions.ReleaseNotFound(raw_query)
 
     def get(self, id):
         """
@@ -80,6 +105,24 @@ class Release(object):
         """
 
         return self.__get_by_option('belongs_to__application', app_id)
+
+    def get_latest_by_application(self, app_id):
+        """
+        Get the latest successful release for an application.
+
+        Args:
+            app_id (str): applicaiton id.
+
+        Returns:
+            dict: release info.
+
+        """
+
+        raw_query = "$top=1&$filter=belongs_to__application%20eq%20'{}'%20and%20status%20eq%20'success'".format(app_id)
+        try:
+            return self.__get_by_raw_query(raw_query)[0]
+        except exceptions.ReleaseNotFound:
+            raise exceptions.ReleaseNotFound(app_id)
 
     def get_with_image_details(self, id):
         """

--- a/balena/settings.py
+++ b/balena/settings.py
@@ -36,9 +36,9 @@ class Settings(object):
     _setting = {
         # These are default config values to write default config file.
         # All values here must be in string format otherwise there will be error when write config file.
-        'pine_endpoint': 'https://api.balena-cloud.com/v4/',
+        'pine_endpoint': 'https://api.balena-cloud.com/v5/',
         'api_endpoint': 'https://api.balena-cloud.com/',
-        'api_version': 'v4',
+        'api_version': 'v5',
         'data_directory': Path.join(HOME_DIRECTORY, '.balena'),
         # cache time : 1 week in milliseconds
         'image_cache_time': str(1 * 1000 * 60 * 60 * 24 * 7),

--- a/tests/functional/models/test_application.py
+++ b/tests/functional/models/test_application.py
@@ -61,6 +61,20 @@ class TestApplication(unittest.TestCase):
         self.balena.models.application.create('FooBar', 'Raspberry Pi 2')
         self.assertEqual(self.balena.models.application.get('FooBar')['app_name'], 'FooBar')
 
+    def test_get_by_owner(self):
+        # raise balena.exceptions.ApplicationNotFound if no application found.
+        with self.assertRaises(self.helper.balena_exceptions.ApplicationNotFound):
+            self.balena.models.application.test_get_by_owner('AppNotExist', self.helper.credentials['user_id'])
+
+        # found an application, it should return an application with matched name.
+        self.balena.models.application.create('FooBar', 'Raspberry Pi 2')
+        self.assertEqual(self.balena.models.application.get('FooBar', self.helper.credentials['user_id'])['app_name'], 'FooBar')
+
+        # should not find the created application with a different username
+        with self.assertRaises(Exception) as cm:
+            self.balena.models.application.get('FooBar', 'random_username')
+        self.assertIn('Application not found: random_username/foobar', cm.exception.message)
+
     def test_has(self):
         # should be true if the application name exists, otherwise it should return false.
         self.balena.models.application.create('FooBar', 'Raspberry Pi 2')

--- a/tests/functional/models/test_application.py
+++ b/tests/functional/models/test_application.py
@@ -64,15 +64,15 @@ class TestApplication(unittest.TestCase):
     def test_get_by_owner(self):
         # raise balena.exceptions.ApplicationNotFound if no application found.
         with self.assertRaises(self.helper.balena_exceptions.ApplicationNotFound):
-            self.balena.models.application.test_get_by_owner('AppNotExist', self.helper.credentials['user_id'])
+            self.balena.models.application.get_by_owner('AppNotExist', self.helper.credentials['user_id'])
 
         # found an application, it should return an application with matched name.
         self.balena.models.application.create('FooBar', 'Raspberry Pi 2')
-        self.assertEqual(self.balena.models.application.get('FooBar', self.helper.credentials['user_id'])['app_name'], 'FooBar')
+        self.assertEqual(self.balena.models.application.get_by_owner('FooBar', self.helper.credentials['user_id'])['app_name'], 'FooBar')
 
         # should not find the created application with a different username
         with self.assertRaises(Exception) as cm:
-            self.balena.models.application.get('FooBar', 'random_username')
+            self.balena.models.application.get_by_owner('FooBar', 'random_username')
         self.assertIn('Application not found: random_username/foobar', cm.exception.message)
 
     def test_has(self):
@@ -167,6 +167,59 @@ class TestApplication(unittest.TestCase):
         self.balena.models.application.revoke_support_access(app['id'])
         app = self.balena.models.application.get('FooBar')
         self.assertIsNone(app['is_accessible_by_support_until__date'])
+
+    def test_will_track_new_releases(self):
+        # should be configured to track new releases by default.
+        app_info = self.helper.create_app_with_releases()
+        self.assertTrue(self.balena.models.application.will_track_new_releases(app_info['app']['id']))
+
+        # should be false when should_track_latest_release is false.
+        self.balena.models.application.disable_rolling_updates(app_info['app']['id'])
+        self.assertFalse(self.balena.models.application.will_track_new_releases(app_info['app']['id']))
+        self.balena.models.application.enable_rolling_updates(app_info['app']['id'])
+        self.assertTrue(self.balena.models.application.will_track_new_releases(app_info['app']['id']))
+
+    def test_is_tracking_latest_release(self):
+        # should be tracking the latest release by default.
+        app_info = self.helper.create_app_with_releases()
+        self.assertTrue(self.balena.models.application.is_tracking_latest_release(app_info['app']['id']))
+
+        # should be false when should_track_latest_release is false.
+        self.balena.models.application.disable_rolling_updates(app_info['app']['id'])
+        self.assertFalse(self.balena.models.application.is_tracking_latest_release(app_info['app']['id']))
+        self.balena.models.application.enable_rolling_updates(app_info['app']['id'])
+        self.assertTrue(self.balena.models.application.is_tracking_latest_release(app_info['app']['id']))
+
+        # should be false when the current commit is not of the latest release.
+        self.balena.models.application.set_to_release(app_info['app']['id'], app_info['old_release']['commit'])
+        # app.set_to_release() will set should_track_latest_release to false so need to set it to true again.
+        self.balena.models.application.enable_rolling_updates(app_info['app']['id'])
+        self.assertFalse(self.balena.models.application.is_tracking_latest_release(app_info['app']['id']))
+
+    def test_get_target_release_hash(self):
+        # should retrieve the commit hash of the current release.
+        app_info = self.helper.create_app_with_releases()
+        self.assertEqual(self.balena.models.application.get_target_release_hash(app_info['app']['id']), app_info['current_release']['commit'])
+
+    def test_set_to_release(self):
+        # should set the application to specific release & disable latest release tracking
+        app_info = self.helper.create_app_with_releases()
+        self.balena.models.application.set_to_release(app_info['app']['id'], app_info['old_release']['commit'])
+        self.assertEqual(self.balena.models.application.get_target_release_hash(app_info['app']['id']), app_info['old_release']['commit'])
+        self.assertFalse(self.balena.models.application.will_track_new_releases(app_info['app']['id']))
+        self.assertFalse(self.balena.models.application.is_tracking_latest_release(app_info['app']['id']))
+
+    def test_track_latest_release(self):
+        # should re-enable latest release tracking
+        app_info = self.helper.create_app_with_releases()
+        self.balena.models.application.set_to_release(app_info['app']['id'], app_info['old_release']['commit'])
+        self.assertEqual(self.balena.models.application.get_target_release_hash(app_info['app']['id']), app_info['old_release']['commit'])
+        self.assertFalse(self.balena.models.application.will_track_new_releases(app_info['app']['id']))
+        self.assertFalse(self.balena.models.application.is_tracking_latest_release(app_info['app']['id']))
+        self.balena.models.application.track_latest_release(app_info['app']['id'])
+        self.assertEqual(self.balena.models.application.get_target_release_hash(app_info['app']['id']), app_info['current_release']['commit'])
+        self.assertTrue(self.balena.models.application.will_track_new_releases(app_info['app']['id']))
+        self.assertTrue(self.balena.models.application.is_tracking_latest_release(app_info['app']['id']))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/functional/models/test_device.py
+++ b/tests/functional/models/test_device.py
@@ -325,6 +325,19 @@ class TestDevice(unittest.TestCase):
         self.balena.models.device.revoke_support_access(device['uuid'])
         self.assertIsNone(self.balena.models.device.get(device['uuid'])['is_accessible_by_support_until__date'])
 
+    def test_is_tracking_application_release(self):
+        app, device = self.helper.create_device()
+
+        # should be tracking the latest release by default.
+        self.assertTrue(self.balena.models.device.is_tracking_application_release(device['uuid']))
+
+    def test_track_application_release(self):
+        app_info = self.helper.create_multicontainer_app()
+
+        # should set the device to track the current application release.
+        self.balena.models.device.set_to_release(app_info['device']['uuid'], app_info['old_release']['commit'])
+        self.balena.models.device.track_application_release(app_info['device']['uuid'])
+        self.assertTrue(self.balena.models.device.is_tracking_application_release(app_info['device']['uuid']))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -327,3 +327,42 @@ class TestHelper(object):
             'old_db_image': old_db_image,
             'current_db_image': new_db_image
         }
+
+    def create_app_with_releases(self, app_name='FooBar', device_type='Raspberry Pi 2'):
+        """
+        Create a multicontainer application with  two releases.
+        """
+
+        app = self.balena.models.application.create(app_name, device_type, 'microservices-starter')
+
+        # Register an old & new release of this application
+
+        data = {
+            'belongs_to__application': app['id'],
+            'is_created_by__user': app['user']['__id'],
+            'commit': 'old-release-commit',
+            'status': 'success',
+            'source': 'cloud',
+            'composition': {},
+            'start_timestamp': 1234
+        }
+
+        old_release = json.loads(self.base_request.request('release', 'POST', data=data, endpoint=self.settings.get('pine_endpoint')).decode('utf-8'))
+
+        data = {
+            'belongs_to__application': app['id'],
+            'is_created_by__user': app['user']['__id'],
+            'commit': 'new-release-commit',
+            'status': 'success',
+            'source': 'cloud',
+            'composition': {},
+            'start_timestamp': 54321
+        }
+
+        new_release = json.loads(self.base_request.request('release', 'POST', data=data, endpoint=self.settings.get('pine_endpoint')).decode('utf-8'))
+
+        return {
+            'app': app,
+            'old_release': old_release,
+            'current_release': new_release
+        }


### PR DESCRIPTION
Connects to https://github.com/balena-io/balena-sdk/pull/597, https://github.com/balena-io/balena-sdk/pull/572.

This PR contains some breaking changes:
- Update to API v5.
- Using some Opensource endpoints.
- Add some release checking methods for staged release support.

