### PR TITLE
env_var: Fix POST parameter name

### DIFF
--- a/balena/models/environment_variables.py
+++ b/balena/models/environment_variables.py
@@ -97,7 +97,7 @@ class DeviceEnvVariable(object):
         device = self.device.get(uuid)
         data = {
             'device': device['id'],
-            'env_var_name': env_var_name,
+            'name': env_var_name,
             'value': value
         }
         new_env_var = json.loads(self.base_request.request(


### PR DESCRIPTION
Connects to https://github.com/balena-io/balena-sdk-python/pull/146, Fixes #145 

In the `create` method the POST parameter for the environment variable name is currently incorrect. It's changed to the value described in the API documentation: `name`.

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>