### PR TITLE
endpoint: Use open-balena-api endpoints for device type & version info

### DIFF
--- a/balena/models/device_os.py
+++ b/balena/models/device_os.py
@@ -217,8 +217,8 @@ class DeviceOs(object):
         """
 
         response = self.base_request.request(
-            'image/{device_type}/versions'.format(device_type=device_type), 'GET',
-            endpoint=self.settings.get('image_maker_endpoint'), auth=False
+            '/device-types/v1/{device_type}/images'.format(device_type=device_type), 'GET',
+            endpoint=self.settings.get('api_endpoint'), auth=False
         )
 
         potential_recommended_versions = [i for i in response['versions'] if not re.search(r'(\.|\+|-)dev', i)]

--- a/balena/settings.py
+++ b/balena/settings.py
@@ -32,7 +32,7 @@ class Settings(object):
     DEFAULT_SETTING_KEYS = set(['pine_endpoint', 'api_endpoint', 'api_version',
                                 'data_directory', 'image_cache_time',
                                 'token_refresh_interval', 'cache_directory', 'timeout',
-                                'image_maker_endpoint', 'device_actions_endpoint_version'])
+                                'device_actions_endpoint_version'])
 
     _setting = {
         # These are default config values to write default config file.
@@ -40,7 +40,6 @@ class Settings(object):
         'pine_endpoint': 'https://api.balena-cloud.com/v5/',
         'api_endpoint': 'https://api.balena-cloud.com/',
         'api_version': 'v5',
-        'image_maker_endpoint': 'https://img.balena-cloud.com/api/v1/',
         'device_actions_endpoint_version': 'v1',
         'data_directory': Path.join(HOME_DIRECTORY, '.balena'),
         # cache time : 1 week in milliseconds


### PR DESCRIPTION
Fixes #141
HQ: https://github.com/balena-io/balena/issues/1744

Remove image maker endpoint in settings since the SDK should only use
the API endpoints as the source of truth for device types.

Change-type: minor
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>