### PR TITLE
os: Allow mixing armv7 and aarch64 devices in RPI 1/zero apps

### DIFF
--- a/balena/models/device_os.py
+++ b/balena/models/device_os.py
@@ -16,7 +16,8 @@ NETWORK_TYPES = [
 ]
 
 ARCH_COMPATIBILITY_MAP = {
-    'aarch64': ['armv7hf']
+    'aarch64': ['armv7hf', 'rpi'],
+    'armv7hf': ['rpi']
 }
 
 


### PR DESCRIPTION
See: https://github.com/balena-io/balena-sdk/pull/740

Change-type: minor
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>