### PR TITLE
Fix using python logging BasicConfig

### DIFF
--- a/balena/models/supervisor.py
+++ b/balena/models/supervisor.py
@@ -1,6 +1,5 @@
 import os
 from pkg_resources import parse_version
-import logging
 
 from ..base_request import BaseRequest
 from ..settings import Settings
@@ -8,11 +7,10 @@ from .. import exceptions
 from .device import Device
 
 
-logging.basicConfig(format='%(levelname)s:%(message)s')
 
 
 def _print_deprecation_warning():
-    logging.warning("This is not supported on multicontainer devices, and will be removed in future")
+    print("This is not supported on multicontainer devices, and will be removed in future")
 
 
 class Supervisor(object):


### PR DESCRIPTION
Change-type: patch

Using logging.basicConfig(...) forces all applications that have:
from balena import Balena

to output all logging messages to stdout, which overrides all logging settings in the application and fills the logs with double printed messages.

For example: (both messages get printed)
From the basicConfig:
INFO:Scanning for adapters 
From the application config:
11/07/2019 01:02:45 Scanning for adapters

See:
https://stackoverflow.com/questions/35325042/python-logging-disable-logging-from-imported-modules