### PR TITLE
Fix release tag tests

### DIFF
--- a/tests/functional/models/test_tag.py
+++ b/tests/functional/models/test_tag.py
@@ -24,9 +24,6 @@ class BaseTagTest(object):
         test_runner.assertEqual(tags[0]['value'], 'Bar')
 
     def test_get_all(self, test_runner, resource_id):
-        # should become an empty array by default
-        test_runner.assertEqual(self.test_obj.get_all(), [])
-
         # given a tag
         self.test_obj.set(resource_id, 'Foo', 'Bar')
         self.test_obj.set(resource_id, 'Foo1', 'Bar1')


### PR DESCRIPTION
- Fix tag.get_all() test: remove the check for empty tag list by default since user should be able to see tag from public application (ESR apps).

- Update tag.set() and tag.remove() test: to make sure these tests work fine when returned result from tag.get_all() contains release_tag from public apps