### PR TITLE
Fix application.has_any() method

### DIFF
--- a/balena/models/application.py
+++ b/balena/models/application.py
@@ -265,10 +265,7 @@ class Application(object):
 
         """
 
-        apps = self.base_request.request(
-            'application', 'GET', endpoint=self.settings.get('pine_endpoint')
-        )['d']
-        return bool(apps)
+        return len(self.get_all()) > 0
 
     def get_by_id(self, app_id):
         """


### PR DESCRIPTION
Check length of result from application.get_all() instead of getting application from `application` endpoint since it returns esr applications as well.

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>