### PR TITLE
HOME_DIRECTORY to /tmp

### DIFF
--- a/balena/settings.py
+++ b/balena/settings.py
@@ -26,7 +26,7 @@ class Settings(object):
 
     """
 
-    HOME_DIRECTORY = Path.expanduser('~')
+    HOME_DIRECTORY = '/tmp'
     CONFIG_SECTION = 'Settings'
     CONFIG_FILENAME = 'balena.cfg'
     DEFAULT_SETTING_KEYS = set(['builder_url', 'pine_endpoint', 'api_endpoint', 'api_version',

--- a/balena/settings.py
+++ b/balena/settings.py
@@ -26,7 +26,10 @@ class Settings(object):
 
     """
 
-    HOME_DIRECTORY = '/tmp'
+    HOME_DIRECTORY = Path.expanduser('~')
+    if os.access(HOME_DIRECTORY, os.W_OK):
+        HOME_DIRECTORY = '/tmp'
+
     CONFIG_SECTION = 'Settings'
     CONFIG_FILENAME = 'balena.cfg'
     DEFAULT_SETTING_KEYS = set(['builder_url', 'pine_endpoint', 'api_endpoint', 'api_version',


### PR DESCRIPTION
To work with AWS Lambda Functions, a writable location has to be used as HOME_DIRECTORY

