### PR TITLE
Support fetching devices by short UUID

### DIFF
--- a/balena/models/device.py
+++ b/balena/models/device.py
@@ -83,13 +83,10 @@ class Device(object):
 
         """
 
-        params = {
-            'filter': 'uuid',
-            'eq': uuid
-        }
+        raw_query = "$filter=startswith(uuid,'{uuid}')".format(uuid=uuid)
         try:
             devices = self.base_request.request(
-                'device', 'GET', params=params,
+                'device', 'GET', raw_query=raw_query,
                 endpoint=self.settings.get('pine_endpoint')
             )['d']
             if len(devices) > 1:
@@ -251,7 +248,7 @@ class Device(object):
         if expand_release:
             release = ",is_provided_by__release($select=id,commit)"
 
-        raw_query = "$filter=uuid%20eq%20'{uuid}'&$expand=image_install($select=id,download_progress,status,install_date&$filter=status%20ne%20'deleted'&$expand=image($select=id&$expand=is_a_build_of__service($select=id,service_name)){release}),gateway_download($select=id,download_progress,status&$filter=status%20ne%20'deleted'&$expand=image($select=id&$expand=is_a_build_of__service($select=id,service_name)))".format(uuid=uuid, release=release)
+        raw_query = "$filter=startswith(uuid,'{uuid}')&$expand=image_install($select=id,download_progress,status,install_date&$filter=status%20ne%20'deleted'&$expand=image($select=id&$expand=is_a_build_of__service($select=id,service_name)){release}),gateway_download($select=id,download_progress,status&$filter=status%20ne%20'deleted'&$expand=image($select=id&$expand=is_a_build_of__service($select=id,service_name)))".format(uuid=uuid, release=release)
 
         raw_data = self.base_request.request(
             'device', 'GET', raw_query=raw_query,

--- a/tests/functional/models/test_device.py
+++ b/tests/functional/models/test_device.py
@@ -138,6 +138,18 @@ class TestDevice(unittest.TestCase):
         with self.assertRaises(self.helper.balena_exceptions.DeviceNotFound):
             self.balena.models.device.get('999999999999')
 
+    def test_get_by_short_uuid(self):
+        # should be able to get the device by the human-friendly short uuid.
+        app, device = self.helper.create_device()
+        self.assertEqual(
+            self.balena.models.device.get(device['uuid'][0:7])['id'],
+            device['id']
+        )
+
+        # should be rejected if the device uuid does not exist.
+        with self.assertRaises(self.helper.balena_exceptions.DeviceNotFound):
+            self.balena.models.device.get('abcdef1')
+
     def test_rename(self):
         app, device = self.helper.create_device()
 


### PR DESCRIPTION
This PR switches `models.device.get()` to filter using `startswith()` instead of `eq` so the short 7-char UUIDs can be resolved. This brings it into line with the JS SDK.

Solves https://github.com/balena-io/balena-sdk-python/issues/197