### PR TITLE
Fix missing arch in device type information

### DIFF
--- a/balena/models/device.py
+++ b/balena/models/device.py
@@ -948,7 +948,7 @@ class Device:
         device_dev_type = list(filter(lambda dev_type: dev_type['slug'] == device['is_of__device_type'][0]['slug'], all_device_types))[0]
         app_dev_type = list(filter(lambda dev_type: dev_type['slug'] == application['is_for__device_type'][0]['slug'], all_device_types))[0]
 
-        if not self.device_os.is_architecture_compatible_with(device_dev_type['arch'], app_dev_type['arch']):
+        if not self.device_os.is_architecture_compatible_with(device_dev_type['is_of__cpu_architecture'][0]['slug'], app_dev_type['is_of__cpu_architecture'][0]['slug']):
             raise exceptions.IncompatibleApplication(app_name)
 
         if bool(device_dev_type.get('isDependent', None)) != bool(app_dev_type.get('isDependent', None)):

--- a/balena/models/device_type.py
+++ b/balena/models/device_type.py
@@ -37,7 +37,7 @@ class DeviceType(object):
 
         """
         
-        raw_query = '$filter=is_default_for__application/any(idfa:idfa/is_host%20eq%20true%20and%20is_archived%20eq%20false)'
+        raw_query = '$expand=is_of__cpu_architecture($select=slug)&$filter=is_default_for__application/any(idfa:idfa/is_host%20eq%20true%20and%20is_archived%20eq%20false)'
 
         return self.base_request.request(
             'device_type', 'GET', raw_query=raw_query,


### PR DESCRIPTION
Fixes #240 
Arch information now returned as slug in is_of__cpu_architecture

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>