### PR TITLE
device: Fix error when parsing balenaOS version before updating OS

### DIFF
--- a/balena/utils.py
+++ b/balena/utils.py
@@ -4,6 +4,7 @@ import numbers
 def is_id(value):
     """
     Return True, if the input value is a valid ID. False otherwise.
+
     """
 
     if isinstance(value, numbers.Number):
@@ -13,3 +14,18 @@ def is_id(value):
         except ValueError:
             return False
     return False
+
+def compare(a, b):
+    """
+
+    Return 1 if a is greater than b, 0 if a is equal to b and -1 otherwise.
+
+    """
+
+    if a > b:
+        return 1
+
+    if b > a:
+        return -1
+
+    return 0


### PR DESCRIPTION
Fixes #250 

There is a change in output of device_os.get_supported_versions method
so device.start_os_update fails to parse current balena OS version
correctly.

Change-type: minor