### PR TITLE
supervisor: Make app_id optional parameter when calling supervisor.ping from outside balena device

### DIFF
--- a/balena/models/supervisor.py
+++ b/balena/models/supervisor.py
@@ -115,7 +115,7 @@ class Supervisor:
         No need to set device uuid and app_id if command is sent to the API on device.
 
         Args:
-            device_uuid (Optional[str]): device uuid.
+            device_uuid (Optional[str]): device uuid, mandatory if not calling this method from the service container on balena device.
             app_id (Optional[str]): application id.
 
         Returns:
@@ -125,22 +125,21 @@ class Supervisor:
             InvalidOption: if the endpoint is balena API proxy endpoint and device_uuid or app_id is not set.
 
         Examples:
-            >>> balena.models.supervisor.ping(device_uuid='8f66ec7335267e7cc7999ca9eec029a01ea7d823214c742ace5cfffaa21be3', app_id='9020')
+            >>> balena.models.supervisor.ping(device_uuid='8f66ec7335267e7cc7999ca9eec029a01ea7d823214c742ace5cfffaa21be3')
             'OK'
 
         """
 
         if not self._on_device:
-            self._check_args(device_uuid, app_id)
+            if device_uuid is None:
+                raise exceptions.MissingOption('device_uuid')
 
             if (self._last_device and self._last_device['uuid'] != device_uuid) or not self._last_device:
                 self._last_device = self.device.get(device_uuid)
 
-            device_id = self._last_device['id']
-
             data = {
-                'deviceId': device_id,
-                'appId': app_id,
+                'deviceId': self._last_device['id'],
+                'appId': self._last_device['belongs_to__application']['__id'],
                 'method': 'GET'
             }
 


### PR DESCRIPTION
app_id can be read from device information so only device_uuid is needed.
Fix #262, the `app_id` parameter will be removed in next major release.

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>