### PR TITLE
Fix device history filter arguments

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -4471,16 +4471,16 @@ This class implements device history model for balena python SDK.
 Get all device history entries for an application.
 
 #### Args:
-    app_id (str): application id.
+    app_id (Union[str, int]): application id.
 
 #### Returns:
     list: device history entries.
 
 #### Examples:
 ```python
->>> balena.models.history.device.get_all_by_application('2036095')
->>> balena.models.history.device.get_all_by_application('2036095', fromDate=datetime.utcnow() + timedelta(days=-5))
->>> balena.models.history.device.get_all_by_application('2036095', fromDate=datetime.utcnow() + timedelta(days=-10), toDate=fromDate = datetime.utcnow() + timedelta(days=-5)))
+>>> balena.models.history.device.get_all_by_application(2036095)
+>>> balena.models.history.device.get_all_by_application(2036095, fromDate=datetime.utcnow() + timedelta(days=-5))
+>>> balena.models.history.device.get_all_by_application(2036095, fromDate=datetime.utcnow() + timedelta(days=-10), toDate=fromDate = datetime.utcnow() + timedelta(days=-5)))
 [
     {
         "id": 48262901,
@@ -4539,9 +4539,9 @@ Get all device history entries for a device.
 ```python
 >>> balena.models.history.device_history.get_all_by_device('6046335305c8142883a4466d30abe211c3a648251556c23520dcff503c9dab')
 >>> balena.models.history.device_history.get_all_by_device('6046335305c8142883a4466d30abe211')
->>> balena.models.history.device_history.get_all_by_device('11196426')
->>> balena.models.history.device_history.get_all_by_device('11196426', fromDate=datetime.utcnow() + timedelta(days=-5))
->>> balena.models.history.device_history.get_all_by_device('11196426', fromDate=datetime.utcnow() + timedelta(days=-10), toDate=fromDate = datetime.utcnow() + timedelta(days=-5)))
+>>> balena.models.history.device_history.get_all_by_device(11196426)
+>>> balena.models.history.device_history.get_all_by_device(11196426, fromDate=datetime.utcnow() + timedelta(days=-5))
+>>> balena.models.history.device_history.get_all_by_device(11196426, fromDate=datetime.utcnow() + timedelta(days=-10), toDate=fromDate = datetime.utcnow() + timedelta(days=-5)))
 [
     {
         "id": 48262901,

--- a/tests/functional/models/test_history.py
+++ b/tests/functional/models/test_history.py
@@ -21,8 +21,11 @@ class TestHistory(unittest.TestCase):
 
     def _test_device_history(self, test_model):
         app_info = self.helper.create_multicontainer_app()
+        # generate some arbitrary devices to test filtering for specific device ID.
+        deviceOne = self.balena.models.device.register(app_info["app"]["id"], self.balena.models.device.generate_uuid())
+        deviceTwo = self.balena.models.device.register(app_info["app"]["id"], self.balena.models.device.generate_uuid())
 
-        def check_device_history(device_history):
+        def check_device_history_by_device(device_history):
             device_history.sort(key=lambda entry: entry["created_at"], reverse=True)
             # this entry should be the newest and have no end_timestamp => not ended history record
             self.assertIsNone(device_history[0]["end_timestamp"])
@@ -30,6 +33,11 @@ class TestHistory(unittest.TestCase):
             for history_entry in device_history:
                 self.assertEqual(history_entry["tracks__device"]["__id"], app_info["device"]["id"])
                 self.assertEqual(history_entry["uuid"], app_info["device"]["uuid"])
+
+            check_device_history_by_application(device_history)
+
+        def check_device_history_by_application(device_history):
+            for history_entry in device_history:
                 self.assertEqual(
                     history_entry["belongs_to__application"]["__id"],
                     app_info["app"]["id"],
@@ -37,31 +45,41 @@ class TestHistory(unittest.TestCase):
 
         # should set the device to track the current application release.
         self.balena.models.device.set_to_release(app_info["device"]["uuid"], app_info["old_release"]["commit"])
+        self.balena.models.device.set_to_release(deviceOne["uuid"], app_info["old_release"]["commit"])
+        self.balena.models.device.set_to_release(deviceTwo["uuid"], app_info["old_release"]["commit"])
 
         # get by device uuid
         device_history = test_model.get_all_by_device(app_info["device"]["uuid"])
-        check_device_history(device_history)
+        check_device_history_by_device(device_history)
 
         # get by device id
         device_history = test_model.get_all_by_device(app_info["device"]["id"])
-        check_device_history(device_history)
+        check_device_history_by_device(device_history)
 
         # get by application id
         device_history = test_model.get_all_by_application(app_info["app"]["id"])
-        check_device_history(device_history)
+        check_device_history_by_application(device_history)
 
         with self.assertRaises(Exception) as cm:
             test_model.get_all_by_device(app_info["device"]["uuid"] + "toManyDigits")
         self.assertIn("Invalid parameter:", cm.exception.message)
 
         for test_set in [
-            {"method": "get_all_by_device", "by": "device"},
-            {"method": "get_all_by_application", "by": "app"},
+            {
+                "method": "get_all_by_device",
+                "by": "device",
+                "checker": check_device_history_by_device,
+            },
+            {
+                "method": "get_all_by_application",
+                "by": "app",
+                "checker": check_device_history_by_application,
+            },
         ]:
             method_under_test = getattr(test_model, test_set["method"])
             device_history = method_under_test(app_info[test_set["by"]]["id"])
 
-            check_device_history(device_history)
+            test_set["checker"](device_history)
 
             # set time range to return device history entries
             device_history = method_under_test(
@@ -69,7 +87,7 @@ class TestHistory(unittest.TestCase):
                 fromDate=datetime.utcnow() + timedelta(days=-10),
                 toDate=datetime.utcnow() + timedelta(days=+1),
             )
-            check_device_history(device_history)
+            test_set["checker"](device_history)
 
             # set time range to return now data
             device_history = method_under_test(


### PR DESCRIPTION
Device history was not filtered by `deviceId`, `deviceUUID` or `applicationID` as SDK created two `$filter` arguments which are not interpreted on the API site.

Change-type: patch