### PR TITLE
Replace `balena.models.supervisor` examples with `device`

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1397,7 +1397,7 @@ This function requires supervisor v1.8 or higher.
 
 #### Examples:
 ```python
->>> balena.models.supervisor.get_application_info('7f66ec')
+>>> balena.models.device.get_application_info('7f66ec')
 ```
 
 <a name="device.get_application_name"></a>
@@ -1737,8 +1737,8 @@ This is useful to signal that the supervisor is alive and responding.
 
 #### Examples:
 ```python
->>> balena.models.supervisor.ping('8f66ec7')
->>> balena.models.supervisor.ping(1234)
+>>> balena.models.device.ping('8f66ec7')
+>>> balena.models.device.ping(1234)
 ```
 
 <a name="device.purge"></a>
@@ -1752,7 +1752,7 @@ This function clears the user application's `/data` directory.
 
 #### Examples:
 ```python
->>> balena.models.supervisor.purge('8f66ec7')
+>>> balena.models.device.purge('8f66ec7')
 ```
 
 <a name="device.reboot"></a>
@@ -1766,7 +1766,7 @@ Reboot the device.
 
 #### Examples:
 ```python
->>> balena.models.supervisor.reboot('8f66ec7')
+>>> balena.models.device.reboot('8f66ec7')
 ```
 
 <a name="device.register"></a>
@@ -1837,7 +1837,7 @@ Restart a service on device.
 
 #### Examples:
 ```python
->>> balena.models.supervisor.restart_service('f3887b', 392229)
+>>> balena.models.device.restart_service('f3887b', 392229)
 ```
 
 <a name="device.revoke_support_access"></a>
@@ -1906,7 +1906,7 @@ Shutdown the device.
 
 #### Examples:
 ```python
->>> balena.models.supervisor.shutdown('8f66ec7')
+>>> balena.models.device.shutdown('8f66ec7')
 ```
 
 <a name="device.start_application"></a>
@@ -1924,7 +1924,7 @@ This function requires supervisor v1.8 or higher.
 
 #### Examples:
 ```python
->>> balena.models.supervisor.start_application('8f66ec7')
+>>> balena.models.device.start_application('8f66ec7')
 ```
 
 <a name="device.start_os_update"></a>
@@ -1959,7 +1959,7 @@ Start a service on device.
 
 #### Examples:
 ```python
->>> balena.models.supervisor.start_service('f3887b1')
+>>> balena.models.device.start_service('f3887b1')
 ```
 
 <a name="device.stop_application"></a>
@@ -1979,7 +1979,7 @@ This function requires supervisor v1.8 or higher.
 
 #### Examples:
 ```python
->>> balena.models.supervisor.stop_application('8f66ec')
+>>> balena.models.device.stop_application('8f66ec')
 ```
 
 <a name="device.stop_service"></a>
@@ -1993,7 +1993,7 @@ Stop a service on device.
 
 #### Examples:
 ```python
->>> balena.models.supervisor.stop_service('f3887b1', 392229)
+>>> balena.models.device.stop_service('f3887b1', 392229)
 ```
 
 <a name="device.track_application_release"></a>
@@ -2028,7 +2028,7 @@ update the device.
 
 #### Examples:
 ```python
->>> balena.models.supervisor.update('8f66ec7')
+>>> balena.models.device.update('8f66ec7')
 ```
 ## DeviceTag
 

--- a/balena/models/device.py
+++ b/balena/models/device.py
@@ -719,8 +719,8 @@ class Device:
             uuid_or_id (Union[str, int]): device uuid (str) or id (int).
 
         Examples:
-            >>> balena.models.supervisor.ping('8f66ec7')
-            >>> balena.models.supervisor.ping(1234)
+            >>> balena.models.device.ping('8f66ec7')
+            >>> balena.models.device.ping(1234)
         """
         device_options = {
             "$select": "id",
@@ -819,7 +819,7 @@ class Device:
             force (Optional[bool]): If force is True, the update lock will be overridden.
 
         Examples:
-            >>> balena.models.supervisor.reboot('8f66ec7')
+            >>> balena.models.device.reboot('8f66ec7')
         """
 
         def __reboot():
@@ -847,7 +847,7 @@ class Device:
             force (Optional[bool]): If force is True, the update lock will be overridden.
 
         Examples:
-            >>> balena.models.supervisor.shutdown('8f66ec7')
+            >>> balena.models.device.shutdown('8f66ec7')
         """
 
         def __shutdown():
@@ -885,7 +885,7 @@ class Device:
             uuid_or_id (Union[str, int]): device uuid (str) or id (int).
 
         Examples:
-            >>> balena.models.supervisor.purge('8f66ec7')
+            >>> balena.models.device.purge('8f66ec7')
         """
 
         def __purge():
@@ -919,7 +919,7 @@ class Device:
             force (Optional[bool]): If force is True, the update lock will be overridden.
 
         Examples:
-            >>> balena.models.supervisor.update('8f66ec7')
+            >>> balena.models.device.update('8f66ec7')
         """
 
         data = {}
@@ -982,7 +982,7 @@ class Device:
             image_id (int): id of the image to start
 
         Examples:
-            >>> balena.models.supervisor.start_service('f3887b1')
+            >>> balena.models.device.start_service('f3887b1')
         """
         device = self.get(
             uuid_or_id,
@@ -1013,7 +1013,7 @@ class Device:
             image_id (int): id of the image to stop
 
         Examples:
-            >>> balena.models.supervisor.stop_service('f3887b1', 392229)
+            >>> balena.models.device.stop_service('f3887b1', 392229)
         """
 
         def __stop_service():
@@ -1052,7 +1052,7 @@ class Device:
             image_id (int): id of the image to restart
 
         Examples:
-            >>> balena.models.supervisor.restart_service('f3887b', 392229)
+            >>> balena.models.device.restart_service('f3887b', 392229)
         """
 
         def __restart_service():
@@ -1681,7 +1681,7 @@ class Device:
             dict: dictionary contains application information.
 
         Examples:
-            >>> balena.models.supervisor.get_application_info('7f66ec')
+            >>> balena.models.device.get_application_info('7f66ec')
         """
 
         device = self.get(
@@ -1716,7 +1716,7 @@ class Device:
             dict: dictionary contains started application container id.
 
         Examples:
-            >>> balena.models.supervisor.start_application('8f66ec7')
+            >>> balena.models.device.start_application('8f66ec7')
         """
 
         device = self.get(
@@ -1755,7 +1755,7 @@ class Device:
             dict: dictionary contains stopped application container id.
 
         Examples:
-            >>> balena.models.supervisor.stop_application('8f66ec')
+            >>> balena.models.device.stop_application('8f66ec')
         """
 
         def __stop_aplication():


### PR DESCRIPTION
The supervisor model has been integrated into the device class, yet some code examples were mistakenly pointing to the wrong model

Fixes #333 
