### PR TITLE
release.get_with_with_details: Set user None when without permissions

### DIFF
--- a/balena/models/release.py
+++ b/balena/models/release.py
@@ -141,7 +141,8 @@ class Release:
             ],
             key=lambda x: x["service_name"],
         )
-        release["user"] = release["is_created_by__user"][0]
+        created_by_user = release["is_created_by__user"]
+        release["user"] = created_by_user[0] if len(created_by_user) > 0 else None
 
         return release
 


### PR DESCRIPTION
This was a bug on balena python sdk which would not mimic the JS sdk behaviour of setting the user as undefined when without reading permissions for it

Change-type: patch