### PR TITLE
Fix typo in /v2/applications/:appId/restart-service Supervisor API call

### DIFF
--- a/balena/models/device.py
+++ b/balena/models/device.py
@@ -1199,7 +1199,7 @@ class Device:
             app_id = device["belongs_to__application"][0]["id"]
             request(
                 method="POST",
-                path=f"/supervisor/v2/applications/{app_id}/restart_service",
+                path=f"/supervisor/v2/applications/{app_id}/restart-service",
                 settings=self.__settings,
                 body={
                     "deviceId": device["id"],

--- a/tests/functional/models/test_environment_variables.py
+++ b/tests/functional/models/test_environment_variables.py
@@ -26,7 +26,7 @@ class TestAppVars(unittest.TestCase):
     def tearDownClass(cls):
         cls.helper.wipe_organization()
 
-    def test_01_get_emtpy_application_vars(self):
+    def test_01_get_empty_application_vars(self):
         for app_var in self.app_vars:
             self.assertIsNone(app_var.get(self.app["id"], "DOES_NOT_EXIST"))
 
@@ -93,7 +93,7 @@ class TestDeviceEnvironmentVariables(unittest.TestCase):
     def tearDownClass(cls):
         cls.helper.wipe_organization()
 
-    def test_01_get_emtpy_device_env_var(self):
+    def test_01_get_empty_device_env_var(self):
         self.assertIsNone(self.device_env_var.get(self.device["id"], "DOES_NOT_EXIST"))
 
         with self.assertRaises(self.helper.balena_exceptions.DeviceNotFound):
@@ -170,7 +170,7 @@ class TestDeviceServiceEnvironmentVariables(unittest.TestCase):
     def tearDownClass(cls):
         cls.helper.wipe_organization()
 
-    def test_01_get_emtpy_device_service_env_var(self):
+    def test_01_get_empty_device_service_env_var(self):
         self.assertIsNone(self.device_service_env_var.get(self.device["id"], self.service["id"], "DOES_NOT_EXIST"))
 
         with self.assertRaises(self.helper.balena_exceptions.ServiceNotFound):
@@ -288,7 +288,7 @@ class TestServiceEnvironmentVariables(unittest.TestCase):
             }
         return service[name]
 
-    def test_01_get_emtpy_service_var(self):
+    def test_01_get_empty_service_var(self):
         for fetch_resource in self.__service_fetch_resources:
             param = self.__get_param(self.app, self.service, fetch_resource)
             self.assertIsNone(self.service_var.get(param, "DOES_NOT_EXIST"))

--- a/tests/functional/test_logs.py
+++ b/tests/functional/test_logs.py
@@ -135,7 +135,7 @@ class TestAuth(unittest.TestCase):
 
         self.balena.logs.unsubscribe(self.uuid)
 
-    def test_06_should_allow_to_unsubiscribe(self):
+    def test_06_should_allow_to_unsubscribe(self):
         results = []
 
         def cb(data):


### PR DESCRIPTION
The API endpoint being called was `/v2/applications/:appId/restart_service` (with underscore) when it should be `/v2/applications/:appId/restart-service` (with dash).

Change-type: patch
Closes: #354