### PR TITLE
Add typing for `update_status` and `last_update_status_event` in the Device resource

### DIFF
--- a/balena/types/models.py
+++ b/balena/types/models.py
@@ -292,6 +292,8 @@ class TypeDevice(TypedDict):
     is_accessible_by_support_until__date: str
     is_connected_to_vpn: bool
     is_locked_until__date: str
+    update_status: Literal[ "rejected", "downloading", "downloaded", "applying changes", "aborted", "done"]
+    last_update_status_event: str
     is_web_accessible: bool
     is_active: bool
     # This is a computed term


### PR DESCRIPTION
Depends-on: https://github.com/balena-io/open-balena-api/pull/1692
Depends-on: https://github.com/balena-io/balena-api/pull/5130

Project: https://balena.fibery.io/Work/Project/Closing-the-loop-on-device-management-465#Project/Closing-the-loop-continued-697

Change-type: minor