### PR TITLE
Validate target OS update version is not same as current

### DIFF
--- a/balena/hup.py
+++ b/balena/hup.py
@@ -45,6 +45,9 @@ def get_hup_action_type(device_type: str, current_version: Optional[str], target
     if Version.parse(target_version).compare(current_version) < 0:
         raise exceptions.OsUpdateError("OS downgrades are not allowed")
 
+    if Version.compare(parsed_current_ver, parsed_target_ver) == 0:
+        raise exceptions.OsUpdateError("Current OS version matches Target OS version")
+
     # For 1.x -> 2.x or 2.x to 2.x only
     if parsed_target_ver.major > 1 and Version.parse(target_version).compare(MIN_TARGET_VERSION) < 0:
         raise exceptions.OsUpdateError("Target balenaOS version must be greater than {0}".format(MIN_TARGET_VERSION))

--- a/tests/functional/models/test_device_os.py
+++ b/tests/functional/models/test_device_os.py
@@ -25,18 +25,21 @@ class TestDevice(unittest.TestCase):
         self.assertGreater(len(supported_device_os_versions["versions"]), 2)
 
     def test_02_get_hup_action_type(self):
+        # Ensure version advances
         testVersion = [
-            "2.108.1+rev2",
-            "2.106.7",
-            "2.98.11+rev4",
-            "2.98.11+rev3",
-            "2.98.11+rev2",
-            "2.98.11",
-            "2.91.5",
             "2.85.2+rev4.prod",
+            "2.91.5",
+            "2.98.11",
+            "2.98.11+rev2",
+            "2.98.11+rev3",
+            "2.98.11+rev4",
+            "2.106.7",
+            "2.108.1+rev2"
         ]
-        for ver in testVersion:
-            get_hup_action_type("", ver, ver)
+        last_ver = testVersion[0]
+        for ver in testVersion[1:]:
+            get_hup_action_type("", last_ver, ver)
+            last_ver = ver
 
     def test_03_get_supervisor_releases_for_cpu_architecture(self):
         # return an empty array if no image was found


### PR DESCRIPTION
The balena-hup-action-utils package [validates](https://github.com/balena-io-modules/balena-hup-action-utils/blob/3cc85eece148652448445851a90d5620b4f7166b/lib/index.ts#L103) this condition for the Node SDK. The Python SDK must do the same. The docs [say](https://docs.balena.io/reference/sdk/python-sdk/latest/#function-start_os_updateuuid_or_id-target_os_version-%E2%87%92-codehupstatusresponsecode) it does. ;-)

This PR is a WIP. Need to resolve how build versions compare. Presently test fails for x.y.z+rev1 vs. x.y.z+rev2 -- they compare as equal.