### PR TITLE
Block OS upgrades from current OS < 2.14.0 and target OS < 2.16.0

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -182,6 +182,7 @@ hesitate to open an issue in GitHub](https://github.com/balena-io/balena-sdk-pyt
             - [is_tracking_application_release(uuid_or_id)](#device.is_tracking_application_release) ⇒ <code>bool</code>
             - [move(uuid_or_id, app_slug_or_uuid_or_id)](#device.move) ⇒ <code>None</code>
             - [pin_to_release(uuid_or_id, full_release_hash_or_id)](#device.pin_to_release) ⇒ <code>None</code>
+            - [pin_to_supervisor_release(uuid_or_id, supervisor_version_or_id)](#device.pin_to_supervisor_release) ⇒ <code>None</code>
             - [ping(uuid_or_id)](#device.ping) ⇒ <code>None</code>
             - [purge(uuid_or_id)](#device.purge) ⇒ <code>None</code>
             - [reboot(uuid_or_id, force)](#device.reboot) ⇒ <code>None</code>
@@ -193,7 +194,6 @@ hesitate to open an issue in GitHub](https://github.com/balena-io/balena-sdk-pyt
             - [revoke_support_access(uuid_or_id_or_ids)](#device.revoke_support_access) ⇒ <code>None</code>
             - [set_custom_location(uuid_or_id_or_ids, location)](#device.set_custom_location) ⇒ <code>None</code>
             - [set_note(uuid_or_id_or_ids, note)](#device.set_note) ⇒ <code>None</code>
-            - [set_supervisor_release(uuid_or_id, supervisor_version_or_id)](#device.set_supervisor_release) ⇒ <code>None</code>
             - [shutdown(uuid_or_id, force)](#device.shutdown) ⇒ <code>None</code>
             - [start_application(uuid_or_id)](#device.start_application) ⇒ <code>None</code>
             - [start_os_update(uuid_or_id, target_os_version)](#device.start_os_update) ⇒ <code>HUPStatusResponse</code>
@@ -1763,7 +1763,19 @@ and not get updated when the current application release changes.
 
 #### Examples:
 ```python
->>> balena.models.device.set_to_release('49b2a', '45c90004de73557ded7274d4896a6db90ea61e36')
+>>> balena.models.device.pin_to_release('49b2a', '45c90004de73557ded7274d4896a6db90ea61e36')
+```
+
+<a name="device.pin_to_supervisor_release"></a>
+### Function: pin_to_supervisor_release(uuid_or_id, supervisor_version_or_id) ⇒ <code>None</code>
+
+Set a specific device to run a particular supervisor release.
+#### Args:
+    uuid_or_id (Union[str, int]): device uuid (string) or id (int)
+    supervisor_version_or_id (Union[str, int]): the version of a released supervisor (string) or id (number)
+#### Examples:
+```python
+>>> balena.models.device.pin_to_supervisor_release('f55dcdd9ada04b11b4d05c1f1c3b4e72', 'v13.0.0')
 ```
 
 <a name="device.ping"></a>
@@ -1922,18 +1934,6 @@ Note a device.
 >>> balena.models.device.note(123, 'test note')
 ```
 
-<a name="device.set_supervisor_release"></a>
-### Function: set_supervisor_release(uuid_or_id, supervisor_version_or_id) ⇒ <code>None</code>
-
-Set a specific device to run a particular supervisor release.
-#### Args:
-    uuid_or_id (Union[str, int]): device uuid (string) or id (int)
-    supervisor_version_or_id (Union[str, int]): the version of a released supervisor (string) or id (number)
-#### Examples:
-```python
->>> balena.models.device.set_supervisor_release('f55dcdd9ada04b11b4d05c1f1c3b4e72', 'v13.0.0')
-```
-
 <a name="device.shutdown"></a>
 ### Function: shutdown(uuid_or_id, force) ⇒ <code>None</code>
 
@@ -1981,8 +1981,7 @@ status, provisioning_state and provisioning_progress entries.
         The version **must** be the exact version number, a "prod" variant
         and greater than the one running on the device.
     run_detached (Optional[bool]): run the update in detached mode.
-        Default behaviour is run_detached=False but is DEPRECATED and will be
-        removed in a future release. Use run_detached=True for more reliable updates.
+        Default behaviour is run_detached=True for more reliable updates.
 
 #### Returns:
     HUPStatusResponse: action response.
@@ -1991,7 +1990,6 @@ status, provisioning_state and provisioning_progress entries.
 ```python
 >>> balena.models.device.start_os_update('b6070f4fea5a4f11b4d05c1f1c3b4e72', '2.29.2+rev1.prod')
 >>> balena.models.device.start_os_update('b6070f4fea5a4f11b4d05c1f1c3b4e72', '2.89.0+rev1')
->>> balena.models.device.start_os_update('b6070f4fea5a4f11b4d05c1f1c3b4e72', '2.89.0+rev1', run_detached=True)
 ```
 
 <a name="device.start_service"></a>

--- a/balena/hup.py
+++ b/balena/hup.py
@@ -4,7 +4,10 @@ from semver.version import Version
 
 from . import exceptions
 
-MIN_TARGET_VERSION = "2.2.0+rev1"
+# The HUP process itself as well as policies set minimum bounds on current/target
+# versions that it can update. These variables allow enforcement of these minimums.
+MIN_CURRENT_VERSION = "2.14.0+rev1"
+MIN_TARGET_VERSION = "2.16.0+rev1"
 
 
 def __get_variant(ver: Version) -> Optional[Literal["dev", "prod"]]:
@@ -45,8 +48,10 @@ def get_hup_action_type(device_type: str, current_version: Optional[str], target
     if Version.parse(target_version).compare(current_version) < 0:
         raise exceptions.OsUpdateError("OS downgrades are not allowed")
 
-    # For 1.x -> 2.x or 2.x to 2.x only
-    if parsed_target_ver.major > 1 and Version.parse(target_version).compare(MIN_TARGET_VERSION) < 0:
-        raise exceptions.OsUpdateError("Target balenaOS version must be greater than {0}".format(MIN_TARGET_VERSION))
+    if Version.parse(current_version).compare(MIN_CURRENT_VERSION) < 0:
+        raise exceptions.OsUpdateError("Current balenaOS version must be at least {0}".format(MIN_CURRENT_VERSION))
+
+    if Version.parse(target_version).compare(MIN_TARGET_VERSION) < 0:
+        raise exceptions.OsUpdateError("Target balenaOS version must be at least {0}".format(MIN_TARGET_VERSION))
 
     return "resinhup{from_v}{to_v}".format(from_v=parsed_current_ver.major, to_v=parsed_target_ver.major)

--- a/balena/models/device.py
+++ b/balena/models/device.py
@@ -1655,7 +1655,7 @@ class Device:
         self.__set(uuid_or_id_or_ids, {"is_pinned_on__release": None})
 
     # TODO: enable device batching
-    def set_supervisor_release(
+    def pin_to_supervisor_release(
         self,
         uuid_or_id: Union[str, int],
         supervisor_version_or_id: Union[str, int],
@@ -1666,7 +1666,7 @@ class Device:
             uuid_or_id (Union[str, int]): device uuid (string) or id (int)
             supervisor_version_or_id (Union[str, int]): the version of a released supervisor (string) or id (number)
         Examples:
-            >>> balena.models.device.set_supervisor_release('f55dcdd9ada04b11b4d05c1f1c3b4e72', 'v13.0.0')
+            >>> balena.models.device.pin_to_supervisor_release('f55dcdd9ada04b11b4d05c1f1c3b4e72', 'v13.0.0')
         """
         device = self.get(
             uuid_or_id,

--- a/balena/models/device.py
+++ b/balena/models/device.py
@@ -1610,7 +1610,7 @@ class Device:
             full_release_hash_or_id (Union[str, int]) : the hash of a successful release (string) or id (number)
 
         Examples:
-            >>> balena.models.device.set_to_release('49b2a', '45c90004de73557ded7274d4896a6db90ea61e36')
+            >>> balena.models.device.pin_to_release('49b2a', '45c90004de73557ded7274d4896a6db90ea61e36')
         """
 
         device = self.get(
@@ -1968,7 +1968,7 @@ class DeviceTag(DependentResource[BaseTagType]):
             List[BaseTagType]: tags list.
 
         Examples:
-            >>> balena.models.device.tags.get_all_by_device('a03ab646c')
+            >>> balena.models.device.tags.get_all_by_device('a03ab646ca5a4f11b4d05c1f1c3b4e72')
         """
 
         id = self.__device.get(uuid_or_id, {"$select": "id"})["id"]

--- a/balena/models/device.py
+++ b/balena/models/device.py
@@ -1703,7 +1703,7 @@ class Device:
         uuid_or_id: Union[str, int],
         target_os_version: str,
         *,  # Force keyword arguments after this point
-        run_detached: Optional[bool] = False,
+        run_detached: Optional[bool] = True,
     ) -> HUPStatusResponse:
         """
         Start an OS update on a device.
@@ -1718,8 +1718,7 @@ class Device:
                 The version **must** be the exact version number, a "prod" variant
                 and greater than the one running on the device.
             run_detached (Optional[bool]): run the update in detached mode.
-                Default behaviour is run_detached=False but is DEPRECATED and will be
-                removed in a future release. Use run_detached=True for more reliable updates.
+                Default behaviour is run_detached=True for more reliable updates.
 
         Returns:
             HUPStatusResponse: action response.
@@ -1727,7 +1726,6 @@ class Device:
         Examples:
             >>> balena.models.device.start_os_update('b6070f4fea5a4f11b4d05c1f1c3b4e72', '2.29.2+rev1.prod')
             >>> balena.models.device.start_os_update('b6070f4fea5a4f11b4d05c1f1c3b4e72', '2.89.0+rev1')
-            >>> balena.models.device.start_os_update('b6070f4fea5a4f11b4d05c1f1c3b4e72', '2.89.0+rev1', run_detached=True)
         """  # noqa: E501
 
         if target_os_version is None or uuid_or_id is None:

--- a/tests/functional/models/test_device_os.py
+++ b/tests/functional/models/test_device_os.py
@@ -19,9 +19,9 @@ class TestDevice(unittest.TestCase):
     def test_01_get_supported_os_versions_by_device_type_slug(self):
         # should become the manifest if the slug is valid.
         supported_device_os_versions = self.balena.models.os.get_supported_os_update_versions(
-            "raspberrypi3", "2.9.6+rev1.prod"
+            "raspberrypi3", "2.15.1+rev2.prod"
         )
-        self.assertEqual(supported_device_os_versions["current"], "2.9.6+rev1.prod")
+        self.assertEqual(supported_device_os_versions["current"], "2.15.1+rev2.prod")
         self.assertIsInstance(supported_device_os_versions["recommended"], str)
         self.assertIsInstance(supported_device_os_versions["versions"], list)
         self.assertGreater(len(supported_device_os_versions["versions"]), 2)
@@ -99,6 +99,19 @@ class TestDevice(unittest.TestCase):
         # device is offline
         with self.assertRaises(self.helper.balena_exceptions.OsUpdateError):
             self.balena.models.device.start_os_update(uuid, "99.99.0")
+
+    def test_05_is_supported_os_update(self):
+        # valid
+        self.assertTrue(self.balena.models.os.is_supported_os_update("raspberrypi3", "2.15.1+rev2.prod", "6.0.10"))
+        self.assertTrue(self.balena.models.os.is_supported_os_update("raspberrypi3", "2.15.1+rev2.prod", "2025.7.0"))
+        # target < v2.16
+        self.assertFalse(
+            self.balena.models.os.is_supported_os_update("raspberrypi3", "2.15.1+rev1.prod", "2.15.1+rev2")
+        )
+        # source < v2.14
+        self.assertFalse(self.balena.models.os.is_supported_os_update("raspberrypi3", "2.7.8+rev2.prod", "6.0.10"))
+        # downgrade
+        self.assertFalse(self.balena.models.os.is_supported_os_update("raspberrypi3", "6.0.10", "2.15.1+rev2.prod"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Update the minimum target OS to v2.16.0 for `start_os_update()`. Also add a minimum for currently running OS to v2.14.0. This value essentially means current OS is running from a Docker image. These values are required to support v4 of the balenahup script, which removes support for older OSes. See balena-os/balenahup#422.

Also a couple of other related simple but major changes:
* Change the default for `start_os_update()` to use detached mode for more reliable updates
* Rename `set_supervisor_release()` to `pin_to_supervisor_release()`

See: https://balena.fibery.io/Work/Project/2183