### PR TITLE
Add pin_to_os_release() for offline updates

### DIFF
--- a/balena/models/device.py
+++ b/balena/models/device.py
@@ -1,12 +1,14 @@
 import binascii
 import datetime
 import os
+import re
 from typing import Any, Callable, List, Optional, TypedDict, Union, cast
 from urllib.parse import urljoin
 
 from deprecated import deprecated
 import requests
 from semver.version import Version
+from semver import compare as semver_compare
 from json.decoder import JSONDecodeError
 
 from .. import exceptions
@@ -211,12 +213,15 @@ class Device:
         if device["os_variant"] != "dev":
             raise exceptions.LocalModeError(Message.DEVICE_OS_TYPE_NOT_SUPPORT_LOCAL_MODE)
 
-    def __check_os_update_target(self, device_info: TypeDevice, target_os_version: str):
+    def __check_os_update_target(self, device_info: TypeDevice, target_os_version: str, mode: str):
+        # Mode must be "start" (start_os_update) to validate device is online.
+        # Otherwise, mode must be "pin" (pin_to_os_release) to relax version comparison
+        # as commented below.
         if "uuid" not in device_info or not device_info["uuid"]:
             raise exceptions.OsUpdateError("The uuid of the device is not available")
 
         uuid = device_info["uuid"]
-        if "is_online" not in device_info or not device_info["is_online"]:
+        if mode == "start" and ("is_online" not in device_info or not device_info["is_online"]):
             raise exceptions.OsUpdateError(f"The device is offline: {uuid}")
 
         if "os_version" not in device_info or not device_info["os_version"]:
@@ -227,6 +232,28 @@ class Device:
 
         if "os_variant" not in device_info:
             raise exceptions.OsUpdateError(f"The os variant of the device is not available: {uuid}")
+
+        # Allow pinning back to current version. This case is specific to pinning because it
+        # is asynchronous, while starting is synchronous.
+        # If versions differ, continue to follow the logic in get_hup_action_type() below.
+        # The code here does not validate minimum OS version. The goal is to disable an earlier
+        # pin to a forward version; so the device already is running the "target" version.
+        if mode == "pin":
+            try:
+                # Must normalize first, since in format like "balenaOS 6.5.19".
+                parsed_current_ver = normalize_balena_semver(device_info["os_version"])
+                # Collect target version and variant.
+                res = re.match(r"^(.+?)(?:\.(dev|prod))?$", target_os_version)
+                # Ensure version and variant match.
+                if (
+                    res.group(1)
+                    and (not res.group(2) or device_info["os_variant"] == res.group(2))
+                    and semver_compare(parsed_current_ver, res.group(1)) == 0
+                ):
+                    return
+            except Exception:
+                # Will be handled below in get_hup_action_type()
+                pass
 
         current_os_version = get_device_os_semver_with_variant(device_info["os_version"], device_info["os_variant"])
 
@@ -1739,10 +1766,10 @@ class Device:
             },
         )
 
-        self.__check_os_update_target(device, target_os_version)
+        self.__check_os_update_target(device, target_os_version, "start")
 
-        all_versions = self.__device_os.get_available_os_versions(device["is_of__device_type"][0]["slug"])
-        if not [v for v in all_versions if target_os_version == v["raw_version"]]:
+        available_versions = self.__device_os.get_available_os_versions(device["is_of__device_type"][0]["slug"])
+        if not [v for v in available_versions if target_os_version == v["raw_version"]]:
             raise exceptions.InvalidParameter("target_os_version", target_os_version)
 
         data = {"parameters": {"target_version": target_os_version}}
@@ -1758,6 +1785,54 @@ class Device:
             path=f"{device['uuid']}/{self.__device_os.OS_UPDATE_ACTION_NAME}",
             body=data,
             endpoint=f"https://actions.{url_base}/{action_api_version}/",
+        )
+
+    def pin_to_os_release(
+        self,
+        uuid_or_id: Union[str, int],
+        target_os_version: str,
+    ) -> None:
+        """
+        Mark a specific device to be updated to a particular OS release
+
+        Args:
+            uuid_or_id (Union[str, int]): device uuid (string) or id (int).
+            target_os_version (str): semver-compatible version for the target device.
+                Unsupported (unpublished) version will result in rejection.
+                The version **must** be the exact version number, a "prod" variant
+                and greater or equal to the one running on the device.
+
+        Examples:
+            >>> balena.models.device.pin_to_os_release('b6070f4fea5a4f11b4d05c1f1c3b4e72', '2.29.2+rev1.prod')
+            >>> balena.models.device.pin_to_os_release('b6070f4fea5a4f11b4d05c1f1c3b4e72', '2.89.0+rev1')
+        """
+
+        if target_os_version is None or uuid_or_id is None:
+            raise exceptions.InvalidParameter("target_os_version or UUID", None)
+
+        # Validate we are retrieving only required properties.
+        device = self.get(
+            uuid_or_id,
+            {
+                "$select": ["id", "uuid", "is_online", "os_version", "os_variant"],
+                "$expand": {"is_of__device_type": {"$select": "slug"}},
+            },
+        )
+
+        self.__check_os_update_target(device, target_os_version, "pin")
+
+        # In contrast to node SDK, includes only finalized versions.
+        available_versions = self.__device_os.get_available_os_versions(device["is_of__device_type"][0]["slug"])
+        releases = [v for v in available_versions if target_os_version == v.get("raw_version")]
+        if not releases:
+            raise exceptions.InvalidParameter("target_os_version", target_os_version)
+
+        self.__pine.patch(
+            {
+                "resource": "device",
+                "id": device["id"],
+                "body": {"should_be_operated_by__release": releases[0]["id"]},
+            }
         )
 
     @deprecated(

--- a/tests/functional/models/test_device_os.py
+++ b/tests/functional/models/test_device_os.py
@@ -10,7 +10,7 @@ class TestDevice(unittest.TestCase):
         cls.helper = TestHelper()
         cls.balena = cls.helper.balena
         cls.helper.wipe_application()
-        cls.app = cls.balena.models.application.create("FooBar", "raspberry-pi2", cls.helper.default_organization["id"])
+        cls.app = cls.balena.models.application.create("FooBar", "raspberrypi3", cls.helper.default_organization["id"])
 
     @classmethod
     def tearDownClass(cls):
@@ -88,7 +88,6 @@ class TestDevice(unittest.TestCase):
         # sanity check
         self.assertEqual(device["uuid"], uuid)
         device["is_online"] = False
-        self.assertEqual(device["is_online"], False)
 
         # Perform sanity checks on input
         with self.assertRaises(self.helper.balena_exceptions.DeviceNotFound):
@@ -96,9 +95,11 @@ class TestDevice(unittest.TestCase):
 
         with self.assertRaises(self.helper.balena_exceptions.InvalidParameter):
             self.balena.models.device.start_os_update(uuid, None)
-        # device is offline
-        with self.assertRaises(self.helper.balena_exceptions.OsUpdateError):
+
+        # Expect the offline check precedes the target version check.
+        with self.assertRaises(self.helper.balena_exceptions.OsUpdateError) as context:
             self.balena.models.device.start_os_update(uuid, "99.99.0")
+        self.assertTrue("device is offline" in str(context.exception))
 
     def test_05_is_supported_os_update(self):
         # valid
@@ -114,6 +115,54 @@ class TestDevice(unittest.TestCase):
         self.assertFalse(self.balena.models.os.is_supported_os_update("raspberrypi3", "2.7.8+rev2.prod", "6.0.10"))
         # downgrade
         self.assertFalse(self.balena.models.os.is_supported_os_update("raspberrypi3", "6.0.10", "2.15.1+rev2.prod"))
+
+    def test_06_pin_to_os_release(self):
+        uuid = self.balena.models.device.generate_uuid()
+        device = self.balena.models.device.register(self.app["id"], uuid)
+        # sanity check
+        self.assertEqual(device["uuid"], uuid)
+        # Device setup: Ensure not online and is on a valid OS version.
+        self.balena.pine.patch(
+            {"resource": "device", "id": device["id"], "body": {"is_online": False, "os_version": "balenaOS 5.3.21"}}
+        )
+
+        # Perform sanity checks on input
+        with self.assertRaises(self.helper.balena_exceptions.DeviceNotFound):
+            self.balena.models.device.pin_to_os_release(99999999, "6.0.10")
+
+        with self.assertRaises(self.helper.balena_exceptions.InvalidParameter):
+            self.balena.models.device.pin_to_os_release(uuid, None)
+
+        # Also indirectly verifies does not encounter a check for online status
+        # since target version check occurs later.
+        with self.assertRaises(self.helper.balena_exceptions.InvalidParameter) as context:
+            self.balena.models.device.pin_to_os_release(uuid, "99.99.0")
+        self.assertTrue("target_os_version" in str(context.exception))
+
+        # Allow pinning to same version
+        self.balena.models.device.pin_to_os_release(uuid, "5.3.21")
+
+    def test_07_pin_to_os_release_with_prod(self):
+        uuid = self.balena.models.device.generate_uuid()
+        device = self.balena.models.device.register(self.app["id"], uuid)
+        # sanity check
+        self.assertEqual(device["uuid"], uuid)
+        # Device setup: Ensure not online and is on a valid OS version.
+        self.balena.pine.patch(
+            {
+                "resource": "device",
+                "id": device["id"],
+                "body": {"is_online": False, "os_version": "balenaOS 2.83.21+rev1", "os_variant": "prod"},
+            }
+        )
+
+        # Allow pinning to same version, but validate variants
+        with self.assertRaises(self.helper.balena_exceptions.OsUpdateError):
+            self.balena.models.device.pin_to_os_release(uuid, "2.83.21+rev1.dev")
+
+        self.balena.models.device.pin_to_os_release(uuid, "2.83.21+rev1.prod")
+
+        self.balena.models.device.pin_to_os_release(uuid, "6.0.10")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds the ability to pin a device to an OS version with `pin_to_os_release()`. Similar to app updates, the OS can be pinned while the device is offline. When the device comes online, we expect the cloud to push the update to the device.

A device may be pinned back to the current OS version. In contrast, `start_os_update()` now requires that the target OS version is not the current OS version.

Depends on #393.

Change-type: minor