### PR TITLE
Replace deprecated UTC datetime helpers

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2471,12 +2471,12 @@ Get all device history entries for an application.
 >>> balena.models.device.history.get_all_by_application('myorg/myapp')
 >>> balena.models.device.history.get_all_by_application(11196426)
 >>> balena.models.device.history.get_all_by_application(
-...     11196426, from_date=datetime.utcnow() + timedelta(days=-5)
+...     11196426, from_date=datetime.now(timezone.utc) + timedelta(days=-5)
 ... )
 >>> balena.models.device.history.get_all_by_application(
 ...     11196426,
-...     from_date=datetime.utcnow() + timedelta(days=-10),
-...     to_date=from_date = datetime.utcnow() + timedelta(days=-5))
+...     from_date=datetime.now(timezone.utc) + timedelta(days=-10),
+...     to_date=from_date = datetime.now(timezone.utc) + timedelta(days=-5))
 ... )
 ```
 
@@ -2499,12 +2499,12 @@ Get all device history entries for a device.
 >>> balena.models.device.history.get_all_by_device('6046335305c8142883a4466d30abe211')
 >>> balena.models.device.history.get_all_by_device(11196426)
 >>> balena.models.device.history.get_all_by_device(
-...     11196426, from_date=datetime.utcnow() + timedelta(days=-5)
+...     11196426, from_date=datetime.now(timezone.utc) + timedelta(days=-5)
 ... )
 >>> balena.models.device.history.get_all_by_device(
 ...     11196426,
-...     from_date=datetime.utcnow() + timedelta(days=-10),
-...     to_date=from_date = datetime.utcnow() + timedelta(days=-5))
+...     from_date=datetime.now(timezone.utc) + timedelta(days=-10),
+...     to_date=from_date = datetime.now(timezone.utc) + timedelta(days=-5))
 ... )
 ```
 ## DeviceType
@@ -2593,7 +2593,7 @@ This method registers a new api key for the current user with the name given.
 ```python
 >>> balena.models.api_key.create_api_key("myApiKey")
 >>> balena.models.api_key.create_api_key("myApiKey", "my api key description")
->>> balena.models.api_key.create_api_key("myApiKey", "my descr", datetime.datetime.utcnow().isoformat())
+>>> balena.models.api_key.create_api_key("myApiKey", "my descr", datetime.datetime.now(datetime.timezone.utc).isoformat())
 ```
 
 <a name="apikey.get_all"></a>

--- a/balena/balena_auth.py
+++ b/balena/balena_auth.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Optional
 from urllib.parse import urljoin
 
@@ -31,8 +31,7 @@ def __should_update_token(token: str, interval: str) -> bool:
         token_data = jwt.decode(token, algorithms=["HS256"], options={"verify_signature": False})
         # dt will be the same as Date.now() in Javascript but converted to
         # milliseconds for consistency with js/sc sdk
-        dt = (datetime.utcnow() - datetime.utcfromtimestamp(0)).total_seconds()
-        dt = dt * 1000
+        dt = datetime.now(timezone.utc).timestamp() * 1000
         age = dt - (int(token_data["iat"]) * 1000)
         return int(age) >= int(interval)
     except jwt.InvalidTokenError:

--- a/balena/models/api_key.py
+++ b/balena/models/api_key.py
@@ -45,7 +45,7 @@ class ApiKey:
         Examples:
             >>> balena.models.api_key.create_api_key("myApiKey")
             >>> balena.models.api_key.create_api_key("myApiKey", "my api key description")
-            >>> balena.models.api_key.create_api_key("myApiKey", "my descr", datetime.datetime.utcnow().isoformat())
+            >>> balena.models.api_key.create_api_key("myApiKey", "my descr", datetime.datetime.now(datetime.timezone.utc).isoformat())
         """
         api_key_body = {"name": name}
 

--- a/balena/models/application.py
+++ b/balena/models/application.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from math import isinf
 from typing import List, Literal, Optional, Union, cast
 from urllib.parse import urljoin
@@ -870,7 +870,7 @@ class Application:
         """
 
         if expiry_timestamp is None or expiry_timestamp <= int(
-            (datetime.utcnow() - datetime.utcfromtimestamp(0)).total_seconds() * 1000
+            datetime.now(timezone.utc).timestamp() * 1000
         ):
             raise exceptions.InvalidParameter("expiry_timestamp", expiry_timestamp)
 

--- a/balena/models/device.py
+++ b/balena/models/device.py
@@ -1585,7 +1585,7 @@ class Device:
         """
 
         if expiry_timestamp is None or expiry_timestamp <= int(
-            (datetime.datetime.utcnow() - datetime.datetime.utcfromtimestamp(0)).total_seconds() * 1000
+            datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000
         ):
             raise exceptions.InvalidParameter("expiry_timestamp", expiry_timestamp)
 

--- a/balena/models/history.py
+++ b/balena/models/history.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Union
 
 from .. import exceptions
@@ -47,7 +47,7 @@ class DeviceHistory:
     def get_all_by_device(
         self,
         uuid_or_id: Union[str, int],
-        from_date: datetime = datetime.utcnow() + timedelta(days=-7),
+        from_date: datetime = datetime.now(timezone.utc) + timedelta(days=-7),
         to_date: Optional[datetime] = None,
         options: AnyObject = {},
     ) -> List[DeviceHistoryType]:
@@ -67,12 +67,12 @@ class DeviceHistory:
             >>> balena.models.device.history.get_all_by_device('6046335305c8142883a4466d30abe211')
             >>> balena.models.device.history.get_all_by_device(11196426)
             >>> balena.models.device.history.get_all_by_device(
-            ...     11196426, from_date=datetime.utcnow() + timedelta(days=-5)
+            ...     11196426, from_date=datetime.now(timezone.utc) + timedelta(days=-5)
             ... )
             >>> balena.models.device.history.get_all_by_device(
             ...     11196426,
-            ...     from_date=datetime.utcnow() + timedelta(days=-10),
-            ...     to_date=from_date = datetime.utcnow() + timedelta(days=-5))
+            ...     from_date=datetime.now(timezone.utc) + timedelta(days=-10),
+            ...     to_date=from_date = datetime.now(timezone.utc) + timedelta(days=-5))
             ... )
 
         """
@@ -89,7 +89,7 @@ class DeviceHistory:
     def get_all_by_application(
         self,
         slug_or_uuid_or_id: Union[str, int],
-        from_date: datetime = datetime.utcnow() + timedelta(days=-7),
+        from_date: datetime = datetime.now(timezone.utc) + timedelta(days=-7),
         to_date: Optional[datetime] = None,
         options: AnyObject = {},
     ) -> List[DeviceHistoryType]:
@@ -109,12 +109,12 @@ class DeviceHistory:
             >>> balena.models.device.history.get_all_by_application('myorg/myapp')
             >>> balena.models.device.history.get_all_by_application(11196426)
             >>> balena.models.device.history.get_all_by_application(
-            ...     11196426, from_date=datetime.utcnow() + timedelta(days=-5)
+            ...     11196426, from_date=datetime.now(timezone.utc) + timedelta(days=-5)
             ... )
             >>> balena.models.device.history.get_all_by_application(
             ...     11196426,
-            ...     from_date=datetime.utcnow() + timedelta(days=-10),
-            ...     to_date=from_date = datetime.utcnow() + timedelta(days=-5))
+            ...     from_date=datetime.now(timezone.utc) + timedelta(days=-10),
+            ...     to_date=from_date = datetime.now(timezone.utc) + timedelta(days=-5))
             ... )
         """
         app_id = self.__application.get(slug_or_uuid_or_id, {"$select": "id"})["id"]

--- a/tests/functional/models/test_api_key.py
+++ b/tests/functional/models/test_api_key.py
@@ -42,7 +42,7 @@ class TestApiKey(unittest.TestCase):
         self.assertIsInstance(key, str)
 
     def test_03_should_be_able_to_create_key_with_expiry_date(self):
-        tomorrow = (datetime.datetime.utcnow() + datetime.timedelta(days=1)).isoformat()
+        tomorrow = (datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)).isoformat()
         key = self.balena.models.api_key.create(
             "apiKeyWithExpiry",
             "apiKeyDescription",

--- a/tests/functional/models/test_application.py
+++ b/tests/functional/models/test_application.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 from tests.helper import TestHelper
 
@@ -118,11 +118,11 @@ class TestApplication(unittest.TestCase):
 
     def test_16_grant_support_access(self):
         app = TestApplication.app
-        expiry_timestamp = int(self.helper.datetime_to_epoch_ms(datetime.utcnow()) - 10000)
+        expiry_timestamp = int(self.helper.datetime_to_epoch_ms(datetime.now(timezone.utc)) - 10000)
         with self.assertRaises(self.helper.balena_exceptions.InvalidParameter):
             self.balena.models.application.grant_support_access(app["id"], expiry_timestamp)
 
-        expiry_time = int(self.helper.datetime_to_epoch_ms(datetime.utcnow()) + 3600 * 1000)
+        expiry_time = int(self.helper.datetime_to_epoch_ms(datetime.now(timezone.utc)) + 3600 * 1000)
         self.balena.models.application.grant_support_access(app["id"], expiry_time)
 
         support_date = datetime.strptime(
@@ -133,7 +133,7 @@ class TestApplication(unittest.TestCase):
 
     def test_17_revoke_support_access(self):
         app = TestApplication.app
-        expiry_time = int((datetime.utcnow() - datetime.utcfromtimestamp(0)).total_seconds() * 1000 + 3600 * 1000)
+        expiry_time = int(datetime.now(timezone.utc).timestamp() * 1000 + 3600 * 1000)
         self.balena.models.application.grant_support_access(app["id"], expiry_time)
         self.balena.models.application.revoke_support_access(app["id"])
 

--- a/tests/functional/models/test_device.py
+++ b/tests/functional/models/test_device.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch, Mock
 
 from balena.models.device import LocationType
@@ -198,12 +198,12 @@ class TestDevice(unittest.TestCase):
         self.assertEqual(device["custom_longitude"], "")
 
     def test_21_grant_support_access(self):
-        expiry_timestamp = int(self.helper.datetime_to_epoch_ms(datetime.utcnow()) - 10000)
+        expiry_timestamp = int(self.helper.datetime_to_epoch_ms(datetime.now(timezone.utc)) - 10000)
 
         with self.assertRaises(self.helper.balena_exceptions.InvalidParameter):
             self.balena.models.device.grant_support_access(TestDevice.device["uuid"], expiry_timestamp)
 
-        expiry_time = int(self.helper.datetime_to_epoch_ms(datetime.utcnow()) + 3600 * 1000)
+        expiry_time = int(self.helper.datetime_to_epoch_ms(datetime.now(timezone.utc)) + 3600 * 1000)
         self.balena.models.device.grant_support_access(TestDevice.device["uuid"], expiry_time)
         support_date = datetime.strptime(  # type: ignore
             self.balena.models.device.get(TestDevice.device["uuid"])["is_accessible_by_support_until__date"],

--- a/tests/functional/models/test_history.py
+++ b/tests/functional/models/test_history.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from tests.helper import TestHelper
 
@@ -81,16 +81,16 @@ class TestHistory(unittest.TestCase):
             # set time range to return device history entries
             device_history = method_under_test(
                 app_info[test_set["by"]]["id"],
-                from_date=datetime.utcnow() + timedelta(days=-10),
-                to_date=datetime.utcnow() + timedelta(days=+1),
+                from_date=datetime.now(timezone.utc) + timedelta(days=-10),
+                to_date=datetime.now(timezone.utc) + timedelta(days=+1),
             )
             test_set["checker"](device_history)
 
             # set time range to return now data
             device_history = method_under_test(
                 app_info[test_set["by"]]["id"],
-                from_date=datetime.utcnow() + timedelta(days=-3000),
-                to_date=datetime.utcnow() + timedelta(days=-2000),
+                from_date=datetime.now(timezone.utc) + timedelta(days=-3000),
+                to_date=datetime.now(timezone.utc) + timedelta(days=-2000),
             )
             self.assertEqual(len(device_history), 0)
 

--- a/tests/functional/test_auth.py
+++ b/tests/functional/test_auth.py
@@ -5,7 +5,7 @@ from balena.exceptions import NotLoggedIn, LoginFailed
 from balena.balena_auth import get_token
 from tests.helper import TestHelper
 from typing import cast
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from balena.auth import ApplicationKeyWhoAmIResponse, UserKeyWhoAmIResponse, DeviceKeyWhoAmIResponse
 import jwt
 
@@ -222,7 +222,7 @@ class TestAuth(unittest.TestCase):
         self.balena.auth.logout()
 
         # force token refresh with an invalid old token should not throw
-        year_ago = int((datetime.utcnow() - timedelta(days=1 * 365)).timestamp())
+        year_ago = int((datetime.now(timezone.utc) - timedelta(days=1 * 365)).timestamp())
         new_token = jwt.encode({"iat": year_ago}, "dummy_secret", algorithm="HS256")
         self.balena.auth.login_with_token(new_token)
         token = get_token(self.balena.auth._Auth__settings)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,7 +1,7 @@
 import configparser
 import os
 import os.path as Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 import jwt
 
@@ -126,7 +126,9 @@ class TestHelper:
                 self.balena.models.api_key.revoke(key["id"])
 
     def datetime_to_epoch_ms(self, dt):
-        return int((dt - datetime.utcfromtimestamp(0)).total_seconds() * 1000)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp() * 1000)
 
     def create_device(self, app_name="FooBar", device_type="raspberry-pi2"):
         """


### PR DESCRIPTION
Fixes #377.

## Summary
- replace deprecated `datetime.utcnow()` / `datetime.utcfromtimestamp(0)` usage with timezone-aware UTC timestamps
- update support-access timestamp checks and token age calculation to use `datetime.now(timezone.utc).timestamp()`
- update history/API-key examples, generated docs, and functional test timestamp helpers

## Validation
- `git diff --check`
- `rg -n utcnow|utcfromtimestamp|datetime\.UTC balena tests DOCUMENTATION.md README.md`
- Not run locally